### PR TITLE
Light effects custom functions

### DIFF
--- a/doc/modules/ROOT/pages/panels/leds/light_effects.adoc
+++ b/doc/modules/ROOT/pages/panels/leds/light_effects.adoc
@@ -10,11 +10,13 @@ Light effects are parametrized and they are not baked in as color keyframes, so 
 
 == Anatomy of a light effect
 
-Every light effect builds on a user-defined color space: a one dimensional _color ramp_ or a two dimensional _color image_:
+Every light effect builds on a user-defined color space: a one dimensional _color ramp_, a two dimensional _color image_ or a _custom function_:
 
 Color ramp:: Color ramps consist of an arbitrary number of color stops at arbitrary positions, and a given interpolation method between the defined color stops. Essentially, the color ramp is a function that takes a number between 0 and 1 and returns a color.
 
 Color image:: Color images are two dimensional analogues of color ramps with discrete colors stored in an image. Color images are basically two dimensional functions: they take two numbers between 0 and 1 (along their normalized X and Y axes) and return a color.
+
+Custom function:: A Python function called for every drone at every frame of the light effect. The function should return a color, a tuple of four numbers ranging between 0 and 1 (r,g,b,a).
 
 The light effect that you define in the panel _produces_ one or two numbers between 0 and 1 for each drone, based on selected output mapping functions. The color ramp turns the first, the color image turns both mapped numbers into the color that gets applied to the drone.
 
@@ -57,6 +59,15 @@ The most trivial usage of a color image is where e.g. the `X` axis represents ti
 Another usage is to project a static image onto the drones in a grid formation, using the properly selected `Gradient (...)` axis assignments on both axis.
 
 Note that there is no interpolation between pixels in the color image, they are selected for each drone and each frame discretely. Therefore, color images should be used with a width/height that correspond to the selected output mapping perfectly (e.g. same height as the number of drones, same width as the number of frames in the light effect etc.), or they are suggested to be smooth images without sharp edges to compensate for the rounding errors of the discrete mapping. You can also scale up a low-resolution image in an external image editor tool and use the scaled-up version to simulate interpolation.
+
+== The custom function
+
+Use the btn:[Effect Type] dropdown list to select a light effect based on a custom function. In this case a file can be selected that contains the Python function that will be used as the custom function for the light effect. The file should contain a Python function with the following named arguments:
+
+```python
+def color_function(frame, time_fraction, drone_index, formation_index, position, drone_count):
+    return (1.0, 1.0, 1.0, 1.0)
+```
 
 == Temporal constraints
 
@@ -109,7 +120,12 @@ Temporal:: All drones will cycle through the color ramp simultaneously throughou
 
 Distance from mesh:: The single static color picked for each drone will be calculated by mapping the normalized distances between the drones and the selected mesh (see the *Mesh* widget) to the color ramp (i.e. the closest drone to the mesh will pick the leftmost color in the ramp, the farthest will pick the rightmost color, all the rest will get a value in between, distributed evenly along the color ramp).
 
-Custom expression:: This is not a valid option yet, in the future it will be used for custom, user-defined orderings.
+Custom expression:: A Python function which returns a number between 0 and 1. The function is called for each drone and each frame of the light effect.
+EXAMPLE:
+```python
+def odd_even(frame, time_fraction, drone_index, formation_index, position, drone_count):
+    return drone_index % 2
+```
 
 == Mapping
 

--- a/doc/modules/ROOT/pages/panels/leds/light_effects.adoc
+++ b/doc/modules/ROOT/pages/panels/leds/light_effects.adoc
@@ -16,7 +16,7 @@ Color ramp:: Color ramps consist of an arbitrary number of color stops at arbitr
 
 Color image:: Color images are two dimensional analogues of color ramps with discrete colors stored in an image. Color images are basically two dimensional functions: they take two numbers between 0 and 1 (along their normalized X and Y axes) and return a color.
 
-Custom function:: A Python function called for every drone at every frame of the light effect. The function should return a color, a tuple of four numbers ranging between 0 and 1 (r,g,b,a).
+Custom function:: A Python function called for every drone at every frame of the light effect. The function should return a color, a tuple of four numbers ranging between 0 and 1 (red, green, blue and alpha components).
 
 The light effect that you define in the panel _produces_ one or two numbers between 0 and 1 for each drone, based on selected output mapping functions. The color ramp turns the first, the color image turns both mapped numbers into the color that gets applied to the drone.
 

--- a/src/addons/ui_skybrush_studio.py
+++ b/src/addons/ui_skybrush_studio.py
@@ -56,6 +56,7 @@ from sbstudio.plugin.model import (
     LEDControlPanelProperties,
     LightEffect,
     LightEffectCollection,
+    ColorFunctionProperties,
     SafetyCheckProperties,
     ScheduleOverride,
     StoryboardEntry,
@@ -151,6 +152,7 @@ from sbstudio.plugin.tasks import (
 #: Custom types in this addon
 types = (
     FormationsPanelProperties,
+    ColorFunctionProperties,
     LightEffect,
     LightEffectCollection,
     ScheduleOverride,

--- a/src/modules/sbstudio/plugin/model/__init__.py
+++ b/src/modules/sbstudio/plugin/model/__init__.py
@@ -4,7 +4,7 @@ from .formations_panel import (
 )
 from .global_settings import DroneShowAddonGlobalSettings
 from .led_control import LEDControlPanelProperties
-from .light_effects import LightEffect, LightEffectCollection
+from .light_effects import LightEffect, LightEffectCollection, ColorFunctionProperties
 from .object_props import DroneShowAddonObjectProperties
 from .safety_check import SafetyCheckProperties, get_overlay as get_safety_check_overlay
 from .settings import DroneShowAddonFileSpecificSettings
@@ -18,6 +18,7 @@ __all__ = (
     "DroneShowAddonProperties",
     "FormationsPanelProperties",
     "LEDControlPanelProperties",
+    "ColorFunctionProperties",
     "LightEffect",
     "LightEffectCollection",
     "SafetyCheckProperties",

--- a/src/modules/sbstudio/plugin/panels/light_effects.py
+++ b/src/modules/sbstudio/plugin/panels/light_effects.py
@@ -81,6 +81,10 @@ class LightEffectsPanel(Panel):
 
                     col = row.column(align=True)
                     col.operator("image.open", icon="FILE_FOLDER", text="")
+                elif entry.type == "FUNCTION":
+                    row = self.layout.box()
+                    row.prop(entry.color_function, "path", text="")
+                    row.prop(entry.color_function, "name", text="")
                 else:
                     row = layout.box()
                     row.alert = True
@@ -99,11 +103,18 @@ class LightEffectsPanel(Panel):
             col.separator()
             col.prop(entry, "mesh")
             col.separator()
-            col.prop(entry, "output")
+            if entry.type == "COLOR_RAMP" or entry.type == "IMAGE":
+                col.prop(entry, "output")
+                if entry.output == "CUSTOM":
+                    col.prop(entry.output_function, "path", text="Fn file")
+                    col.prop(entry.output_function, "name", text="Fn name")
             if output_type_supports_mapping_mode(entry.output):
                 col.prop(entry, "output_mapping_mode")
             if entry.type == "IMAGE":
                 col.prop(entry, "output_y")
+                if entry.output_y == "CUSTOM":
+                    col.prop(entry.output_function_y, "path", text="Fn file")
+                    col.prop(entry.output_function_y, "name", text="Fn name")
                 if output_type_supports_mapping_mode(entry.output_y):
                     col.prop(entry, "output_mapping_mode_y")
             col.prop(entry, "target")

--- a/src/modules/sbstudio/utils.py
+++ b/src/modules/sbstudio/utils.py
@@ -1,3 +1,5 @@
+import importlib.util
+
 from collections import OrderedDict
 from collections.abc import MutableMapping
 from pathlib import Path
@@ -87,6 +89,20 @@ def _simplify_line(points, *, eps, distance_func):
         post = _simplify_line(points[index:], eps=eps, distance_func=distance_func)
         return pre[:-1] + post
 
+
+def load_module(path: str) -> Any:
+    """Loads a module and returns it.
+
+    Parameters:
+        path: the path to the module.
+
+    Returns:
+        the loaded module.
+    """
+    spec = importlib.util.spec_from_file_location("colors_module", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 class LRUCache(MutableMapping):
     """Size-limited cache with least-recently-used eviction policy."""


### PR DESCRIPTION
This PR adds support for color functions in two ways:
1. In the Type dropdown next to "Color ramp" and "Image". The function should return an RGBA tuple.
2. The "Custom expression" output which was already there as a placeholder. The function should return a number between 0 and 1 which will be used to get the color of the color ramp or the pixel in the color image.

Example of how it can be used to add color animations in a bit more dynamic way than creating 2D images for the Image type:
```python
# note: `if` conditions for readability, could be optimized in 1 line of math
def fade_sorted(frame, time_fraction, drone_index, formation_index, position, drone_count):
    factor = min(max(drone_count * (1.1 * time_fraction - formation_index / drone_count), 0.0), 1.0)
    if formation_index >= 112:
        return factor * 1.0
    if formation_index % 2 == 0:
        return 0.66 * factor
    return 0.33 * factor
```

https://github.com/skybrush-io/studio-blender/assets/66438062/9e5caf9a-d264-48f4-8bdc-e833644e0329
