### PR TITLE
fix: formations list dropdown

### DIFF
--- a/src/modules/sbstudio/plugin/model/formation.py
+++ b/src/modules/sbstudio/plugin/model/formation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import bpy
 
+from bpy.types import Collection
 from functools import partial
 from itertools import count
 from mathutils import Vector
@@ -17,7 +18,7 @@ from sbstudio.plugin.utils import create_object_in_collection
 from sbstudio.plugin.utils.evaluator import get_position_of_object
 
 if TYPE_CHECKING:
-    from bpy.types import Collection, MeshVertex, Object
+    from bpy.types import MeshVertex, Object
 
 __all__ = (
     "add_objects_to_formation",


### PR DESCRIPTION
The formations dropdown is not displaying any formations anymore due to a NameError:
```
Traceback (most recent call last):
  File "~/Library/Application Support/Blender/4.0/scripts/addons/vendor/skybrush/sbstudio/plugin/props/formation.py", line 10, in _is_formation
    return is_formation(object)
  File "~/Library/Application Support/Blender/4.0/scripts/addons/vendor/skybrush/sbstudio/plugin/model/formation.py", line 249, in is_formation
    if not isinstance(object, Collection):
NameError: name 'Collection' is not defined. Did you mean: 'Collections'?
```
caused by https://github.com/skybrush-io/studio-blender/commit/57a0c507eb1e66cc1abb9dbb9842134a4342bd4e#diff-5d9f0714c7b9ba49b973103efbe8b635c8527ea849bb112944d2a6e8011243b0R20