### PR TITLE
fix: light effects

### DIFF
--- a/src/modules/sbstudio/plugin/tasks/light_effects.py
+++ b/src/modules/sbstudio/plugin/tasks/light_effects.py
@@ -81,11 +81,11 @@ def update_light_effects(scene: Scene, depsgraph: Depsgraph):
                 colors: list[RGBAColor] = []
                 for drone in drones:
                     color = get_led_light_color(drone)
-                    colors.append(color)
+                    colors.append(list(color)) # convert to list for in place modification
                     _base_color_cache[id(drone)] = color
             else:
                 # Initialize the colors list from the cached base colors
-                colors = [_base_color_cache.get(id(drone), WHITE) for drone in drones]
+                colors = [list(_base_color_cache.get(id(drone), WHITE)) for drone in drones]
             changed = True
 
         effect.apply_on_colors(

--- a/src/modules/sbstudio/plugin/tasks/light_effects.py
+++ b/src/modules/sbstudio/plugin/tasks/light_effects.py
@@ -80,12 +80,14 @@ def update_light_effects(scene: Scene, depsgraph: Depsgraph):
                 # the base color cache in parallel to the colors list
                 colors: list[RGBAColor] = []
                 for drone in drones:
-                    color = get_led_light_color(drone)
-                    colors.append(list(color)) # convert to list for in place modification
+                    color = list(get_led_light_color(drone))
+                    colors.append(color)
                     _base_color_cache[id(drone)] = color
             else:
                 # Initialize the colors list from the cached base colors
-                colors = [list(_base_color_cache.get(id(drone), WHITE)) for drone in drones]
+                colors = [
+                    _base_color_cache.get(id(drone)) or list(WHITE) for drone in drones
+                ]
             changed = True
 
         effect.apply_on_colors(


### PR DESCRIPTION
```
  File "~/Library/Application Support/Blender/4.0/scripts/addons/vendor/skybrush/sbstudio/math/colors.py", line 153, in blend_in_place
    backdrop[:] = source
TypeError: 'tuple' object does not support item assignment
```
due to the recent caching changes