### PR TITLE
feat: sorted formation objects

### DIFF
--- a/src/modules/sbstudio/plugin/selection.py
+++ b/src/modules/sbstudio/plugin/selection.py
@@ -58,7 +58,7 @@ def get_selected_objects(*, context: Optional[Context] = None):
         the list of selected objects, taking into account the current mode
     """
     if context.mode == "OBJECT":
-        return context.selected_objects
+        return sorted(context.selected_objects, key=lambda obj: obj.name) # sort for light effects order
     else:
         active_object = context.active_object
         return [active_object] if active_object else []


### PR DESCRIPTION
This helps to have a configurable order when using objects with vertex groups in order to use formation_index more easily.