### PR TITLE
feat: add purpose to storyboard entries and export segments to .skyc

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.3.5
+    rev: v0.8.4
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,10 @@ pyclean = "^2.0.0"
 [tool.ruff]
 lint.ignore = ["B027", "B905", "C901", "E402", "E501", "E731"]
 lint.select = ["B", "C", "E", "F", "W"]
-extend-exclude = ["src/modules/sbstudio/vendor"]
+extend-exclude = [
+    "src/modules/sbstudio/vendor",
+    "src/modules/sbstudio/i18n/translations.py"
+]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/src/modules/sbstudio/plugin/model/light_effects.py
+++ b/src/modules/sbstudio/plugin/model/light_effects.py
@@ -3,18 +3,10 @@ from __future__ import annotations
 import types
 import bpy
 
+from collections.abc import Callable, Iterable, Sequence
 from functools import partial
 from operator import itemgetter
-from typing import (
-    cast,
-    Callable,
-    Iterable,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    TYPE_CHECKING,
-)
+from typing import cast, Optional
 
 from bpy.path import abspath
 from bpy.props import (
@@ -54,9 +46,6 @@ from sbstudio.utils import constant, distance_sq_of, load_module, negate
 
 from .mixins import ListMixin
 
-if TYPE_CHECKING:
-    from sbstudio.api.types import Mapping
-    from sbstudio.plugin.model import StoryboardEntry
 
 __all__ = ("ColorFunctionProperties", "LightEffect", "LightEffectCollection")
 
@@ -159,8 +148,8 @@ def test_is_in_front_of(plane: Optional[Plane], point: Coordinate3D) -> bool:
 _always_true = constant(True)
 
 
-def get_color_function_names(self, context: Context) -> List[Tuple[str, str, str]]:
-    names: List[str]
+def get_color_function_names(self, context: Context) -> list[tuple[str, str, str]]:
+    names: list[str]
 
     if self.path:
         absolute_path = abspath(self.path)
@@ -398,7 +387,7 @@ class LightEffect(PropertyGroup):
         self,
         colors: Sequence[MutableRGBAColor],
         positions: Sequence[Coordinate3D],
-        mapping: Optional[List[int]],
+        mapping: Optional[list[int]],
         *,
         frame: int,
         random_seq: RandomSequence,
@@ -422,7 +411,7 @@ class LightEffect(PropertyGroup):
             output_type: str,
             mapping_mode: str,
             output_function,
-        ) -> Tuple[Optional[List[Optional[float]]], Optional[float]]:
+        ) -> tuple[Optional[list[Optional[float]]], Optional[float]]:
             """Get the float output(s) for color ramp or image indexing based on the output type.
 
             Args:
@@ -432,9 +421,9 @@ class LightEffect(PropertyGroup):
             Returns:
                 individual and common outputs
             """
-            outputs: Optional[List[Optional[float]]] = None
+            outputs: Optional[list[Optional[float]]] = None
             common_output: Optional[float] = None
-            order: Optional[List[int]] = None
+            order: Optional[list[int]] = None
 
             if output_type == "FIRST_COLOR":
                 common_output = 0.0

--- a/src/modules/sbstudio/plugin/operators/create_new_storyboard_entry.py
+++ b/src/modules/sbstudio/plugin/operators/create_new_storyboard_entry.py
@@ -1,4 +1,13 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from .base import StoryboardOperator
+
+if TYPE_CHECKING:
+    from bpy.types import Context
+
+    from sbstudio.plugin.model.storyboard import Storyboard
 
 __all__ = ("CreateNewStoryboardEntryOperator",)
 
@@ -10,6 +19,6 @@ class CreateNewStoryboardEntryOperator(StoryboardOperator):
     bl_label = "Create New Storyboard Entry"
     bl_description = "Creates a new storyboard entry at the end of the storyboard."
 
-    def execute_on_storyboard(self, storyboard, context):
+    def execute_on_storyboard(self, storyboard: Storyboard, context: Context):
         storyboard.add_new_entry(name="Untitled", select=True)
         return {"FINISHED"}

--- a/src/modules/sbstudio/plugin/operators/create_takeoff_grid.py
+++ b/src/modules/sbstudio/plugin/operators/create_takeoff_grid.py
@@ -4,7 +4,6 @@ from bpy.props import BoolProperty, FloatProperty, IntProperty
 from bpy.types import Operator
 
 from numpy import array, column_stack, mgrid, repeat, tile, zeros
-from typing import List
 
 from sbstudio.model.types import Coordinate3D
 from sbstudio.plugin.constants import Collections, Formations, Templates
@@ -13,7 +12,7 @@ from sbstudio.plugin.materials import (
     create_keyframe_for_diffuse_color_of_material,
 )
 from sbstudio.plugin.model.formation import add_points_to_formation, create_formation
-from sbstudio.plugin.model.storyboard import get_storyboard
+from sbstudio.plugin.model.storyboard import StoryboardEntryPurpose, get_storyboard
 from sbstudio.plugin.operators.detach_materials_from_template import (
     detach_material_from_drone_template,
 )
@@ -64,7 +63,7 @@ def create_points_of_takeoff_grid(
     spacing_col: float = 1,
     intra_slot_spacing_row: float = 0.5,
     intra_slot_spacing_col: float = 0.5,
-) -> List[Coordinate3D]:
+) -> list[Coordinate3D]:
     """Creates the points of a takeoff grid centered at the given coordinate.
 
     Parameters:
@@ -390,6 +389,7 @@ class CreateTakeoffGridOperator(Operator):
                 formation=create_formation(Formations.TAKEOFF_GRID, points),
                 frame_start=context.scene.frame_start,
                 duration=0,
+                purpose=StoryboardEntryPurpose.TAKEOFF,
                 select=True,
                 context=context,
             )

--- a/src/modules/sbstudio/plugin/operators/land.py
+++ b/src/modules/sbstudio/plugin/operators/land.py
@@ -11,7 +11,11 @@ from sbstudio.plugin.api import call_api_from_blender_operator
 from sbstudio.plugin.constants import Collections
 from sbstudio.plugin.model.formation import create_formation
 from sbstudio.plugin.model.safety_check import get_proximity_warning_threshold
-from sbstudio.plugin.model.storyboard import get_storyboard
+from sbstudio.plugin.model.storyboard import (
+    Storyboard,
+    StoryboardEntryPurpose,
+    get_storyboard,
+)
 from sbstudio.plugin.utils.evaluator import create_position_evaluator
 from sbstudio.plugin.utils.transition import find_transition_constraint_between
 
@@ -68,14 +72,14 @@ class LandOperator(StoryboardOperator):
     )
 
     @classmethod
-    def poll(cls, context):
+    def poll(cls, context: Context):
         if not super().poll(context):
             return False
 
         drones = Collections.find_drones(create=False)
         return drones is not None and len(drones.objects) > 0
 
-    def invoke(self, context, event):
+    def invoke(self, context: Context, event):
         self.start_frame = max(
             context.scene.frame_current, get_storyboard(context=context).frame_end
         )
@@ -89,7 +93,7 @@ class LandOperator(StoryboardOperator):
             success = False
         return {"FINISHED"} if success else {"CANCELLED"}
 
-    def _run(self, storyboard, *, context) -> bool:
+    def _run(self, storyboard: Storyboard, *, context: Context) -> bool:
         bpy.ops.skybrush.prepare()
 
         if not self._validate_start_frame(context):
@@ -166,6 +170,7 @@ class LandOperator(StoryboardOperator):
             frame_start=end_of_landing,
             duration=0,
             select=True,
+            purpose=StoryboardEntryPurpose.LANDING,
             context=context,
         )
         assert entry is not None

--- a/src/modules/sbstudio/plugin/operators/prepare.py
+++ b/src/modules/sbstudio/plugin/operators/prepare.py
@@ -1,6 +1,6 @@
 from bpy.types import Operator
 
-from sbstudio.plugin.constants import Collections, Templates
+from sbstudio.plugin.constants import Collections
 from sbstudio.plugin.objects import link_object_to_scene
 from sbstudio.plugin.state import get_file_specific_state
 

--- a/src/modules/sbstudio/plugin/operators/remove_storyboard_entry.py
+++ b/src/modules/sbstudio/plugin/operators/remove_storyboard_entry.py
@@ -1,8 +1,17 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from sbstudio.plugin.constants import Collections
 from sbstudio.plugin.model.storyboard import get_storyboard
 from sbstudio.plugin.utils.transition import find_transition_constraint_between
 
 from .base import StoryboardOperator
+
+if TYPE_CHECKING:
+    from bpy.types import Context
+
+    from sbstudio.plugin.model.storyboard import Storyboard, StoryboardEntry
 
 __all__ = ("RemoveStoryboardEntryOperator",)
 
@@ -15,19 +24,19 @@ class RemoveStoryboardEntryOperator(StoryboardOperator):
     bl_description = "Remove the selected entry from the storyboard"
 
     @classmethod
-    def poll(cls, context):
+    def poll(cls, context: Context):
         return (
             StoryboardOperator.poll(context)
             and get_storyboard(context=context).active_entry is not None
         )
 
-    def execute_on_storyboard(self, storyboard, context):
+    def execute_on_storyboard(self, storyboard: Storyboard, context: Context):
         remove_constraints_for_storyboard_entry(storyboard.active_entry)
         storyboard.remove_active_entry()
         return {"FINISHED"}
 
 
-def remove_constraints_for_storyboard_entry(entry):
+def remove_constraints_for_storyboard_entry(entry: StoryboardEntry):
     if not entry:
         return
 

--- a/src/modules/sbstudio/plugin/operators/return_to_home.py
+++ b/src/modules/sbstudio/plugin/operators/return_to_home.py
@@ -1,3 +1,5 @@
+from collections.abc import Sequence
+
 import bpy
 
 from bpy.props import FloatProperty, IntProperty, BoolProperty
@@ -6,6 +8,7 @@ from functools import partial
 from math import ceil, sqrt
 
 from sbstudio.errors import SkybrushStudioError
+from sbstudio.model.types import Coordinate3D
 from sbstudio.plugin.api import call_api_from_blender_operator
 from sbstudio.plugin.constants import Collections
 from sbstudio.plugin.actions import (
@@ -14,7 +17,11 @@ from sbstudio.plugin.actions import (
 )
 from sbstudio.plugin.model.formation import create_formation, get_markers_from_formation
 from sbstudio.plugin.model.safety_check import get_proximity_warning_threshold
-from sbstudio.plugin.model.storyboard import get_storyboard
+from sbstudio.plugin.model.storyboard import (
+    Storyboard,
+    StoryboardEntryPurpose,
+    get_storyboard,
+)
 from sbstudio.plugin.utils.evaluator import create_position_evaluator
 
 from .base import StoryboardOperator
@@ -96,14 +103,14 @@ class ReturnToHomeOperator(StoryboardOperator):
     )
 
     @classmethod
-    def poll(cls, context):
+    def poll(cls, context: Context):
         if not super().poll(context):
             return False
 
         drones = Collections.find_drones(create=False)
         return drones is not None and len(drones.objects) > 0
 
-    def draw(self, context):
+    def draw(self, context: Context):
         layout = self.layout
         layout.use_property_split = True
 
@@ -135,7 +142,7 @@ class ReturnToHomeOperator(StoryboardOperator):
         )
         return context.window_manager.invoke_props_dialog(self)
 
-    def execute_on_storyboard(self, storyboard, entries, context):
+    def execute_on_storyboard(self, storyboard: Storyboard, entries, context: Context):
         try:
             success = self._run(storyboard, context=context)
         except SkybrushStudioError:
@@ -146,7 +153,7 @@ class ReturnToHomeOperator(StoryboardOperator):
     def _should_use_smart_rth(self) -> bool:
         return self.use_smart_rth and is_smart_rth_enabled_globally()
 
-    def _run(self, storyboard, *, context) -> bool:
+    def _run(self, storyboard: Storyboard, *, context: Context) -> bool:
         bpy.ops.skybrush.prepare()
 
         if not self._validate_start_frame(context):
@@ -173,134 +180,156 @@ class ReturnToHomeOperator(StoryboardOperator):
             min_distance=get_proximity_warning_threshold(context),
             operator=self,
         )
-        fps = context.scene.render.fps
 
-        if use_smart_rth:
-            # Set up non-trivial parameters
-            # TODO: get them as explicit parameter if needed
-            settings = getattr(context.scene.skybrush, "settings", None)
-            max_acceleration = settings.max_acceleration if settings else 4
-            min_distance = get_proximity_warning_threshold(context)
-            land_speed = min(self.velocity_z, 0.5)
-
-            # call API to create smart RTH plan
-            with call_api_from_blender_operator(self) as api:
-                plan = api.plan_smart_rth(
-                    source,
-                    target,
-                    max_velocity_xy=self.velocity,
-                    max_velocity_z=self.velocity_z,
-                    max_acceleration=max_acceleration,
-                    min_distance=min_distance,
-                    rth_model="straight_line_with_neck",
-                )
-            if not plan.start_times or not plan.durations:
-                return False
-
-            # Add a new storyboard entry for the smart RTH formation
-            # TODO: What should happen if there is already a formation with the
-            # same name?
-            entry = storyboard.add_new_entry(
-                formation=create_formation("Smart return to home", source),
-                frame_start=self.start_frame,
-                duration=int(ceil((plan.duration + self.altitude / land_speed) * fps)),
-                select=True,
-                context=context,
-            )
-            assert entry is not None
-            markers = get_markers_from_formation(entry.formation)
-
-            # generate smart RTH trajectories in the new formation
-            for start_time, duration, inner_points, p, q, marker in zip(
-                plan.start_times,
-                plan.durations,
-                plan.inner_points,
-                source,
-                target,
-                markers,
-                strict=True,
-            ):
-                action = ensure_action_exists_for_object(
-                    marker, name=f"Animation data for {marker.name}", clean=True
-                )
-
-                f_curves = []
-                for i in range(3):
-                    f_curve = find_f_curve_for_data_path_and_index(
-                        action, "location", i
-                    )
-                    if f_curve is None:
-                        f_curve = action.fcurves.new("location", index=i)
-                    else:
-                        # We should clear the keyframes that fall within the
-                        # range of our keyframes. Currently it's not needed because
-                        # it's a freshly created marker so it can't have any
-                        # keyframes that we don't know about.
-                        print(f"Already existing F-curve! {marker.name} {i}")
-                        pass
-                    f_curves.append(f_curve)
-                insert = [
-                    partial(f_curve.keyframe_points.insert, options={"FAST"})
-                    for f_curve in f_curves
-                ]
-                path_points = []
-                if start_time > 0:
-                    path_points.append((0, *p))
-                path_points.append((start_time, *p))
-                path_points.extend(tuple(inner_points))
-                path_points.extend(
-                    (
-                        (start_time + duration, *q),
-                        (
-                            start_time + duration + self.altitude / land_speed,
-                            q[0],
-                            q[1],
-                            0,  # TODO: starting position would be better than explicit 0
-                        ),
-                    )
-                )
-                for point in path_points:
-                    frame = int(self.start_frame + point[0] * fps)
-                    keyframes = (
-                        insert[0](frame, point[1]),
-                        insert[1](frame, point[2]),
-                        insert[2](frame, point[3]),
-                    )
-                    for keyframe in keyframes:
-                        keyframe.interpolation = "LINEAR"
-                # Commit the insertions that we've made in "fast" mode
-                for f_curve in f_curves:
-                    f_curve.update()
-        else:
-            diffs = [
-                sqrt((s[0] - t[0]) ** 2 + (s[1] - t[1]) ** 2 + (s[2] - t[2]) ** 2)
-                for s, t in zip(source, target)
-            ]
-
-            # Calculate RTH duration from max distance to travel and the
-            # average velocity
-            max_distance = max(diffs)
-            rth_duration = ceil((max_distance / self.velocity) * fps)
-
-            # Extend the duration of the last formation to the frame where we want
-            # to start the RTH maneuver
-            if len(storyboard.entries) > 0:
-                storyboard.last_entry.extend_until(self.start_frame)
-
-            # Calculate when the RTH should end
-            end_of_rth = self.start_frame + rth_duration
-
-            # Add a new storyboard entry with the given formation
-            storyboard.add_new_entry(
-                formation=create_formation("Return to home", target),
-                frame_start=end_of_rth,
-                duration=0,
-                select=True,
-                context=context,
-            )
+        run_rth = self._run_smart_rth if use_smart_rth else self._run_base_rth
+        result = run_rth(storyboard, source=source, target=target, context=context)
 
         # Recalculate the transition leading to the target formation
         bpy.ops.skybrush.recalculate_transitions(scope="TO_SELECTED")
+        return result
+
+    def _run_base_rth(
+        self,
+        storyboard: Storyboard,
+        *,
+        source: Sequence[Coordinate3D],
+        target: Sequence[Coordinate3D],
+        context: Context,
+    ) -> bool:
+        fps = context.scene.render.fps
+        diffs = [
+            sqrt((s[0] - t[0]) ** 2 + (s[1] - t[1]) ** 2 + (s[2] - t[2]) ** 2)
+            for s, t in zip(source, target)
+        ]
+
+        # Calculate RTH duration from max distance to travel and the
+        # average velocity
+        max_distance = max(diffs)
+        rth_duration = ceil((max_distance / self.velocity) * fps)
+
+        # Extend the duration of the last formation to the frame where we want
+        # to start the RTH maneuver
+        if len(storyboard.entries) > 0:
+            storyboard.last_entry.extend_until(self.start_frame)
+
+        # Calculate when the RTH should end
+        end_of_rth = self.start_frame + rth_duration
+
+        # Add a new storyboard entry with the given formation
+        storyboard.add_new_entry(
+            formation=create_formation("Return to home", target),
+            frame_start=end_of_rth,
+            duration=0,
+            select=True,
+            purpose=StoryboardEntryPurpose.LANDING,
+            context=context,
+        )
+
+    def _run_smart_rth(
+        self,
+        storyboard: Storyboard,
+        *,
+        source: Sequence[Coordinate3D],
+        target: Sequence[Coordinate3D],
+        context: Context,
+    ) -> bool:
+        fps = context.scene.render.fps
+
+        # Set up non-trivial parameters
+        # TODO: get them as explicit parameter if needed
+        settings = getattr(context.scene.skybrush, "settings", None)
+        max_acceleration = settings.max_acceleration if settings else 4
+        min_distance = get_proximity_warning_threshold(context)
+        land_speed = min(self.velocity_z, 0.5)
+
+        # call API to create smart RTH plan
+        with call_api_from_blender_operator(self) as api:
+            plan = api.plan_smart_rth(
+                source,
+                target,
+                max_velocity_xy=self.velocity,
+                max_velocity_z=self.velocity_z,
+                max_acceleration=max_acceleration,
+                min_distance=min_distance,
+                rth_model="straight_line_with_neck",
+            )
+        if not plan.start_times or not plan.durations:
+            return False
+
+        # Add a new storyboard entry for the smart RTH formation
+        # TODO: What should happen if there is already a formation with the
+        # same name?
+        entry = storyboard.add_new_entry(
+            formation=create_formation("Smart return to home", source),
+            frame_start=self.start_frame,
+            duration=int(ceil((plan.duration + self.altitude / land_speed) * fps)),
+            select=True,
+            purpose=StoryboardEntryPurpose.LANDING,
+            context=context,
+        )
+        assert entry is not None
+        markers = get_markers_from_formation(entry.formation)
+
+        # generate smart RTH trajectories in the new formation
+        for start_time, duration, inner_points, p, q, marker in zip(
+            plan.start_times,
+            plan.durations,
+            plan.inner_points,
+            source,
+            target,
+            markers,
+            strict=True,
+        ):
+            action = ensure_action_exists_for_object(
+                marker, name=f"Animation data for {marker.name}", clean=True
+            )
+
+            f_curves = []
+            for i in range(3):
+                f_curve = find_f_curve_for_data_path_and_index(action, "location", i)
+                if f_curve is None:
+                    f_curve = action.fcurves.new("location", index=i)
+                else:
+                    # We should clear the keyframes that fall within the
+                    # range of our keyframes. Currently it's not needed because
+                    # it's a freshly created marker so it can't have any
+                    # keyframes that we don't know about.
+                    print(f"Already existing F-curve! {marker.name} {i}")
+                    pass
+                f_curves.append(f_curve)
+            insert = [
+                partial(f_curve.keyframe_points.insert, options={"FAST"})
+                for f_curve in f_curves
+            ]
+            path_points = []
+            if start_time > 0:
+                path_points.append((0, *p))
+            path_points.append((start_time, *p))
+            path_points.extend(tuple(inner_points))
+            path_points.extend(
+                (
+                    (start_time + duration, *q),
+                    (
+                        start_time + duration + self.altitude / land_speed,
+                        q[0],
+                        q[1],
+                        0,  # TODO: starting position would be better than explicit 0
+                    ),
+                )
+            )
+            for point in path_points:
+                frame = int(self.start_frame + point[0] * fps)
+                keyframes = (
+                    insert[0](frame, point[1]),
+                    insert[1](frame, point[2]),
+                    insert[2](frame, point[3]),
+                )
+                for keyframe in keyframes:
+                    keyframe.interpolation = "LINEAR"
+            # Commit the insertions that we've made in "fast" mode
+            for f_curve in f_curves:
+                f_curve.update()
+
         return True
 
     def _validate_start_frame(self, context: Context) -> bool:

--- a/src/modules/sbstudio/plugin/operators/run_full_proximity_check.py
+++ b/src/modules/sbstudio/plugin/operators/run_full_proximity_check.py
@@ -1,4 +1,3 @@
-from numpy import array, float32
 from typing import Literal
 
 from bpy.types import Context, Operator

--- a/src/modules/sbstudio/plugin/operators/takeoff.py
+++ b/src/modules/sbstudio/plugin/operators/takeoff.py
@@ -4,7 +4,6 @@ from bpy.props import BoolProperty, FloatProperty, IntProperty
 from bpy.types import Context
 from math import ceil, inf
 
-from sbstudio.api.errors import SkybrushStudioAPIError
 from sbstudio.errors import SkybrushStudioError
 from sbstudio.math.nearest_neighbors import find_nearest_neighbors
 from sbstudio.plugin.api import call_api_from_blender_operator, get_api
@@ -14,7 +13,11 @@ from sbstudio.plugin.model.formation import (
     ensure_formation_consists_of_points,
 )
 from sbstudio.plugin.model.safety_check import get_proximity_warning_threshold
-from sbstudio.plugin.model.storyboard import get_storyboard, Storyboard
+from sbstudio.plugin.model.storyboard import (
+    Storyboard,
+    StoryboardEntryPurpose,
+    get_storyboard,
+)
 from sbstudio.plugin.operators.recalculate_transitions import (
     RecalculationTask,
     recalculate_transitions,
@@ -103,7 +106,7 @@ class TakeoffOperator(StoryboardOperator):
         self.start_frame = int(max(min(context.scene.frame_current, end), start))
         return context.window_manager.invoke_props_dialog(self)
 
-    def execute_on_storyboard(self, storyboard, entries, context: Context):
+    def execute_on_storyboard(self, storyboard: Storyboard, entries, context: Context):
         try:
             success = self._run(storyboard, context=context)
         except SkybrushStudioError:
@@ -176,6 +179,7 @@ class TakeoffOperator(StoryboardOperator):
                 formation=create_formation(Formations.TAKEOFF_GRID, source),
                 frame_start=self.start_frame,
                 duration=0,
+                purpose=StoryboardEntryPurpose.TAKEOFF,
                 select=False,
                 context=context,
             )
@@ -193,6 +197,7 @@ class TakeoffOperator(StoryboardOperator):
             formation=create_formation(Formations.TAKEOFF, target),
             frame_start=end_of_takeoff,
             duration=0,
+            purpose=StoryboardEntryPurpose.TAKEOFF,
             select=True,
             context=context,
         )

--- a/src/modules/sbstudio/plugin/panels/storyboard_editor.py
+++ b/src/modules/sbstudio/plugin/panels/storyboard_editor.py
@@ -77,6 +77,7 @@ class StoryboardEditor(Panel):
             col.prop(entry, "duration")
             col.prop(entry, "frame_end")
             col.prop(entry, "is_name_customized")
+            col.prop(entry, "purpose")
             col.popover(
                 "OBJECT_PT_skybrush_transition_editor_pre",
                 icon="TRACKING_CLEAR_BACKWARDS",

--- a/src/modules/sbstudio/plugin/tasks/light_effects.py
+++ b/src/modules/sbstudio/plugin/tasks/light_effects.py
@@ -17,7 +17,6 @@ from sbstudio.plugin.utils.evaluator import get_position_of_object
 
 if TYPE_CHECKING:
     from bpy.types import Depsgraph, Scene
-    from sbstudio.api.types import Mapping
 
 __all__ = ("UpdateLightEffectsTask",)
 

--- a/src/modules/sbstudio/utils.py
+++ b/src/modules/sbstudio/utils.py
@@ -1,10 +1,10 @@
 import importlib.util
 
 from collections import OrderedDict
-from collections.abc import MutableMapping
+from collections.abc import Callable, Iterable, MutableMapping, Sequence
 from functools import wraps
 from pathlib import Path
-from typing import Any, Callable, Generic, List, Sequence, TypeVar
+from typing import Any, Generic, Optional, TypeVar
 
 from sbstudio.model.types import Coordinate3D
 
@@ -46,6 +46,28 @@ def distance_sq_of(p: Coordinate3D, q: Coordinate3D) -> float:
     return (p[0] - q[0]) ** 2 + (p[1] - q[1]) ** 2 + (p[2] - q[2]) ** 2
 
 
+def get_ends(items: Optional[Iterable[T]]) -> tuple[T, T] | None:
+    """
+    Returns the first and last item from the given iterable as a tuple if the
+    iterable is not empty, otherwise returns `None`.
+
+    If the iterable contains only one item, then first and last will be that one item.
+    """
+    if items is None:
+        return None
+
+    iterator = iter(items)
+    try:
+        first = last = next(iterator)
+    except StopIteration:
+        return None
+
+    for item in iterator:
+        last = item
+
+    return (first, last)
+
+
 def negate(func: Callable[..., bool]) -> Callable[..., bool]:
     """Decorator that takes a function that returns a Boolean value and returns
     another function that returns the negation of the result of the original
@@ -60,7 +82,7 @@ def negate(func: Callable[..., bool]) -> Callable[..., bool]:
 
 
 def simplify_path(
-    points: Sequence[T], *, eps: float, distance_func: Callable[[List[T], T, T], float]
+    points: Sequence[T], *, eps: float, distance_func: Callable[[list[T], T, T], float]
 ) -> Sequence[T]:
     """Simplifies a sequence of points to a similar sequence with fewer
     points, using a distance function and an acceptable error term.


### PR DESCRIPTION
Changes:

- Ruff commit hook upgrade
- Some typing improvements
- Some refactoring (e.g. rth, storyboard)
- Add a `purpose` enum property to `StoryboardEntry`
- Calculate show segments based on `StoryboardEntry.purpose` and make this info available for export
- `get_storyboard()` now only accepts keyword only arguments (`with_context` only supports context in keyword args)