### PR TITLE
feat/check-backend-version

### DIFF
--- a/src/modules/sbstudio/api/base.py
+++ b/src/modules/sbstudio/api/base.py
@@ -31,7 +31,7 @@ from sbstudio.utils import create_path_and_open
 
 from .constants import COMMUNITY_SERVER_URL
 from .errors import SkybrushStudioAPIError
-from .types import Limits, Mapping, SmartRTHPlan, TransitionPlan
+from .types import Limits, Mapping, SmartRTHPlan, TransitionPlan, Version
 
 __all__ = ("SkybrushStudioAPI",)
 
@@ -642,6 +642,11 @@ class SkybrushStudioAPI:
         """Returns the limits and supported file formats of the server."""
         with self._send_request("queries/limits") as response:
             return Limits.from_json(response.as_json())
+
+    def get_version(self) -> Version:
+        """Returns the version of the server."""
+        with self._send_request("queries/version") as response:
+            return Version.from_json(response.as_json())
 
     def match_points(
         self,

--- a/src/modules/sbstudio/api/types.py
+++ b/src/modules/sbstudio/api/types.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 from math import inf
+from re import fullmatch
 from typing import Any, List, Optional
 
 Mapping = list[Optional[int]]
@@ -130,3 +131,39 @@ class TransitionPlan:
             if self.start_times and self.durations
             else 0.0
         )
+
+
+@dataclass(order=True, frozen=True)
+class Version:
+    """Response returned from a "query version" API request,
+    i.e., a semantic version number."""
+
+    major: int
+    minor: int
+    patch: int
+
+    @classmethod
+    def from_json(cls, obj: Any):
+        if not isinstance(obj, dict):
+            raise TypeError("version object can only be constructed from a dict")
+
+        version = obj.get("version")
+        if version is None:
+            raise TypeError("version object does not contain version string")
+
+        return cls.from_string(version)
+
+    @classmethod
+    def from_string(cls, version_str: str):
+        """Parses a semantic version from its string representation."""
+        match = fullmatch(r"(\d+)\.(\d+)\.(\d+)", version_str.strip())
+        if not match:
+            raise ValueError(f"Invalid version string: {version_str}")
+        major, minor, patch = map(int, match.groups())
+        return cls(major, minor, patch)
+
+    def to_tuple(self):
+        return (self.major, self.minor, self.patch)
+
+    def __str__(self):
+        return f"{self.major}.{self.minor}.{self.patch}"

--- a/src/modules/sbstudio/model/version.py
+++ b/src/modules/sbstudio/model/version.py
@@ -7,6 +7,7 @@ _version: Version
 __all__ = (
     "get_backend_version",
     "is_backend_version_ok",
+    "update_backend_version",
 )
 
 

--- a/src/modules/sbstudio/model/version.py
+++ b/src/modules/sbstudio/model/version.py
@@ -1,0 +1,35 @@
+from sbstudio.api.types import Version
+from sbstudio.plugin.constants import MINIMUM_BACKEND_VERSION
+
+_version: Version
+
+
+__all__ = (
+    "get_backend_version",
+    "is_backend_version_ok",
+)
+
+
+def is_backend_version_ok() -> bool:
+    """Returns whether the stored backend version is above the
+    current minimum requirement."""
+    global _version
+
+    return _version >= MINIMUM_BACKEND_VERSION
+
+
+def get_backend_version() -> Version:
+    """Returns the version of the server backend."""
+    global _version
+
+    return _version
+
+
+def update_backend_version(version: Version) -> None:
+    """Updates the backend version object returned from a server API call."""
+    global _version
+
+    _version = version
+
+
+update_backend_version(MINIMUM_BACKEND_VERSION)

--- a/src/modules/sbstudio/plugin/constants.py
+++ b/src/modules/sbstudio/plugin/constants.py
@@ -14,6 +14,8 @@ from typing import (
     overload,
 )
 
+from sbstudio.api.types import Version
+
 from .materials import create_colored_material, create_glowing_material
 from .meshes import create_icosphere, create_cone
 from .utils import (
@@ -45,6 +47,9 @@ DEFAULT_INDOOR_DRONE_RADIUS = 0.1
 
 DEFAULT_OUTDOOR_DRONE_RADIUS = 0.5
 """Default outdoor drone radius"""
+
+MINIMUM_BACKEND_VERSION = Version(2, 29, 0)
+"""The minimum version of the backend that is compatible with this version of the plugin."""
 
 NUM_PYRO_CHANNELS = 6
 """The number of pyro channels that we support."""

--- a/src/modules/sbstudio/plugin/operators/refresh_file_formats.py
+++ b/src/modules/sbstudio/plugin/operators/refresh_file_formats.py
@@ -1,7 +1,13 @@
 from bpy.types import Operator
 
 from sbstudio.model.file_formats import update_supported_file_formats_from_limits
+from sbstudio.model.version import (
+    get_backend_version,
+    is_backend_version_ok,
+    update_backend_version,
+)
 from sbstudio.plugin.api import call_api_from_blender_operator
+from sbstudio.plugin.constants import MINIMUM_BACKEND_VERSION
 
 __all__ = ("RefreshFileFormatsOperator",)
 
@@ -9,6 +15,9 @@ __all__ = ("RefreshFileFormatsOperator",)
 class RefreshFileFormatsOperator(Operator):
     """Queries the server for the list of file formats that are supported by
     the server.
+
+    Note that operator also checks the backend version in the background and
+    informs the user if the backend is outdated.
     """
 
     bl_idname = "skybrush.refresh_file_formats"
@@ -22,6 +31,15 @@ class RefreshFileFormatsOperator(Operator):
                 self, "server capabilities query"
             ) as api:
                 update_supported_file_formats_from_limits(api.get_limits())
+                update_backend_version(api.get_version())
         except Exception:
             return {"CANCELLED"}
+
+        if not is_backend_version_ok():
+            self.report(
+                {"WARNING"},
+                f"Skybrush Studio Server is outdated ({get_backend_version()}), "
+                f"update to {MINIMUM_BACKEND_VERSION} or above!",
+            )
+
         return {"FINISHED"}


### PR DESCRIPTION
This PR retrieves the backend version when executing the RefreshFileFormats operator and checks if that meets the minimum requirement. TODOs:

- [ ] once the `feat/json-v2` branch gets merged into main, we can merge that here and decide which trajectory format version to use based on the current backend version.
