### PR TITLE
fix: more detailed http error messages

### DIFF
--- a/src/modules/sbstudio/api/base.py
+++ b/src/modules/sbstudio/api/base.py
@@ -5,6 +5,7 @@ from base64 import b64encode
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from gzip import compress
+from http import HTTPStatus
 from http.client import HTTPResponse
 from io import IOBase, TextIOWrapper
 from natsort import natsorted
@@ -129,6 +130,9 @@ class SkybrushStudioAPI:
     _root: str
     """The root URL of the API, with a trailing slash"""
 
+    _http_status: dict[int | None, str]
+    """Predefined http status messages."""
+
     @staticmethod
     def validate_api_key(key: str) -> str:
         """Validates the given API key.
@@ -163,6 +167,8 @@ class SkybrushStudioAPI:
         """
         self._root = None  # type: ignore
         self._request_context = create_default_context()
+        self._http_status = {status.value: status.phrase for status in HTTPStatus}
+        self._http_status[None] = "HTTP error"
 
         if api_key and license_file:
             raise SkybrushStudioAPIError(
@@ -273,9 +279,9 @@ class SkybrushStudioAPI:
                 response._run_sanity_checks()
                 yield response
         except HTTPError as ex:
-            # If the status code is 400 or 403, we may have more details about the
+            # If the status code is 400, 403 or 500, we may have more details about the
             # error in the response itself
-            if ex.status in (400, 403):
+            if ex.status in (400, 403, 500):
                 try:
                     body = ex.read().decode("utf-8")
                 except Exception:
@@ -289,8 +295,9 @@ class SkybrushStudioAPI:
                     # got an empty object
                     decoded_body = {}
                 if isinstance(decoded_body, dict) and decoded_body.get("detail"):
+                    detail = str(decoded_body.get("detail"))
                     raise SkybrushStudioAPIError(
-                        str(decoded_body.get("detail"))
+                        f"{self._http_status[ex.status]}: {detail}"
                     ) from None
             elif ex.status == 413:
                 # Content too large
@@ -302,8 +309,8 @@ class SkybrushStudioAPI:
 
             # No detailed information about the error so use a generic message
             raise SkybrushStudioAPIError(
-                f"HTTP error {ex.status}. This is most likely a "
-                f"server-side issue; please contact us and let us know."
+                f"{self._http_status[ex.status]} ({ex.status}). "
+                f"This is most likely a server-side issue; please contact us and let us know."
             ) from ex
 
     def _skip_ssl_checks(self) -> None:


### PR DESCRIPTION
This is a very small PR to have a bit better pretty printing error messages on server request failures. Also details error 500 that is server timeout (comes along with backend PR).