### PR TITLE
feat/pyro-info

### DIFF
--- a/src/modules/sbstudio/plugin/model/pyro_control.py
+++ b/src/modules/sbstudio/plugin/model/pyro_control.py
@@ -8,6 +8,7 @@ from sbstudio.plugin.constants import Collections, NUM_PYRO_CHANNELS
 from sbstudio.plugin.utils.pyro_markers import update_pyro_particles_of_object
 from sbstudio.plugin.overlays.pyro import (
     PyroOverlay,
+    PyroOverlayInfo,
     PyroOverlayMarker,
 )
 
@@ -54,6 +55,7 @@ class PyroControlPanelProperties(PropertyGroup):
             ("NONE", "None", "No rendering is very quick but invisible", 1),
             ("MARKERS", "Markers", "Markers are simple but quick", 2),
             ("PARTICLES", "Particles", "Particles are spectacular but slow", 3),
+            ("INFO", "Info", "Static pyro info for aiding pre-flight handling", 4),
         ],
         name="Visualization",
         description=("The visualization method of the pyro effect."),
@@ -105,7 +107,7 @@ class PyroControlPanelProperties(PropertyGroup):
             overlay.markers = []
 
     def ensure_overlays_enabled_if_needed(self) -> None:
-        get_overlay().enabled = self.visualization == "MARKERS"
+        get_overlay().enabled = self.visualization in ["MARKERS", "INFO"]
 
     def update_pyro_overlay_markers(self, markers: list[PyroOverlayMarker]) -> None:
         """Updates the pyro overlay markers."""
@@ -114,3 +116,13 @@ class PyroControlPanelProperties(PropertyGroup):
         overlay = get_overlay(create=False)
         if overlay:
             overlay.markers = markers
+
+    def update_pyro_overlay_info_blocks(
+        self, info_blocks: list[PyroOverlayInfo]
+    ) -> None:
+        """Updates the pyro overlay info blocks."""
+        self.ensure_overlays_enabled_if_needed()
+
+        overlay = get_overlay(create=False)
+        if overlay:
+            overlay.info_blocks = info_blocks

--- a/src/modules/sbstudio/plugin/overlays/pyro.py
+++ b/src/modules/sbstudio/plugin/overlays/pyro.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import blf
 import bpy
 import gpu
 
+from bpy_extras.view3d_utils import location_3d_to_region_2d
+from bpy.types import SpaceView3D
 from gpu_extras.batch import batch_for_shader
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from sbstudio.model.types import Coordinate3D
 
@@ -31,6 +34,11 @@ __all__ = (
 Color = tuple[float, float, float]
 """Type alias for RGB colors in this module."""
 
+PyroOverlayInfo = tuple[Coordinate3D, list[str]]
+"""Type specification for a single info block on the overlay. An info block requires 
+a single coordinate and a list of text strings (one per line).
+"""
+
 PyroOverlayMarker = tuple[Coordinate3D, Color]
 """Type specification for a single marker on the overlay. A marker requires 
 a single coordinate and a Color.
@@ -41,14 +49,33 @@ DEFAULT_PYRO_OVERLAY_MARKER_COLOR: Color = (0.5, 0.5, 0.5)
 
 
 class PyroOverlay(ShaderOverlay):
-    """Overlay that marks the closest pair of drones and all drones above the
-    altitude threshold in the 3D view.
-    """
+    """Overlay that marks pyro drones in the 3D view."""
 
     shader_type = "FLAT_COLOR"
 
+    _info_blocks: list[PyroOverlayInfo] | None = None
     _markers: list[PyroOverlayMarker] | None = None
     _shader_batches: list[GPUBatch] | None = None
+
+    @property
+    def info_blocks(self) -> list[PyroOverlayInfo] | None:
+        return self._info_blocks
+
+    @info_blocks.setter
+    def info_blocks(self, value: list[PyroOverlayInfo] | None):
+        if value is not None:
+            self._info_blocks = []
+            for point, lines in value:
+                info_block = (
+                    tuple(float(c) for c in point),
+                    lines,
+                )
+                self._info_blocks.append(info_block)  # type: ignore
+
+        else:
+            self._info_blocks = None
+
+        # self._shader_batches = None
 
     @property
     def markers(self) -> list[PyroOverlayMarker] | None:
@@ -71,7 +98,51 @@ class PyroOverlay(ShaderOverlay):
         self._shader_batches = None
 
     def draw_2d(self) -> None:
-        return
+        context = bpy.context
+        skybrush = getattr(context.scene, "skybrush", None)
+        pyro_control: PyroControlPanelProperties | None = getattr(
+            skybrush, "pyro_control", None
+        )
+        if (
+            not pyro_control
+            or self._info_blocks is None
+            or pyro_control.visualization != "INFO"
+        ):
+            return
+
+        space_data = context.space_data
+        if space_data.type != "VIEW_3D":
+            return
+
+        space_data = cast(SpaceView3D, space_data)
+        if not hasattr(space_data, "overlay") or not bool(
+            getattr(space_data.overlay, "show_overlays", False)
+        ):
+            return
+
+        font_id = 0
+        ui_scale = self.get_ui_scale()
+        region = context.region
+        region_3d = context.region_data
+        font_size = int(11 * ui_scale)
+        line_height = font_size + 2
+
+        if bpy.app.version >= (4, 0, 0):
+            # DPI argument was removed in Blender 4.0
+            blf.size(font_id, font_size)
+        else:
+            blf.size(font_id, font_size, 72)
+        blf.enable(font_id, blf.SHADOW)
+        blf.color(font_id, 1, 1, 1, 1)
+
+        for info_block in self._info_blocks:
+            num_lines = len(info_block[1])
+            x, y = location_3d_to_region_2d(region, region_3d, info_block[0])
+            y += (num_lines - 3 / 2) * font_size / 2
+            for line in info_block[1]:
+                blf.position(font_id, x, y, 0)
+                blf.draw(font_id, line)
+                y -= line_height
 
     def draw_3d(self) -> None:
         if has_gpu_state_module:
@@ -83,7 +154,7 @@ class PyroOverlay(ShaderOverlay):
         pyro_control: PyroControlPanelProperties | None = getattr(
             skybrush, "pyro_control", None
         )
-        if not pyro_control or pyro_control.visualization != "MARKERS":
+        if not pyro_control or pyro_control.visualization not in ["MARKERS", "INFO"]:
             return
 
         if self._markers is not None:


### PR DESCRIPTION
This PR adds a new render option to pyro visualization with highlighting drones that trigger pyro and adding text to them summarizing pyro details. This visualization type can be used to aid preflight pyro setup with giving details on which drones should be equipped in the takeoff grid with what pyro payloads on the different channels. TODOs:

- [ ] Visualization does not show up at startup if a file is opened in the Info render type state.
- [ ] documentation
- [ ] update readme