### PR TITLE
check both positive and negative axis's for inside mesh

### DIFF
--- a/src/modules/sbstudio/plugin/model/light_effects.py
+++ b/src/modules/sbstudio/plugin/model/light_effects.py
@@ -60,7 +60,7 @@ def object_has_mesh_data(self, obj) -> bool:
     return obj.data and isinstance(obj.data, Mesh)
 
 
-CONTAINMENT_TEST_AXES = (Vector((1, 0, 0)), Vector((0, 1, 0)), Vector((0, 0, 1)))
+CONTAINMENT_TEST_AXES = (Vector((1, 0, 0)), Vector((0, 1, 0)), Vector((0, 0, 1)), Vector((-1, 0, 0)), Vector((0, -1, 0)), Vector((0, 0, -1)))
 """Pre-constructed vectors for a quick containment test using raycasting and BVH-trees"""
 
 OUTPUT_TYPE_TO_AXIS_SORT_KEY = {


### PR DESCRIPTION
This fixes an issue I encountered where drones nearby a object that was set with a LED effect as inside mesh would be lit up depending on their orientation to the object. This is because the raycast check that was performed is only done for the 3 positive axis's, not the negative. Editing this array to include both positive and negative axis's makes this check significantly more consistent