### PR TITLE
feat: add time offset param to vviz exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [main]
+
+### Changed
+
+- The `.vviz` exporter got enhanced in several ways. It received a new time offset 
+  parameter to be able to move the drone show time axis relative to the time axis 
+  of the software importing the `.vviz`. It also encodes a pan and tilt angle for
+  the pyro payloads now, based on the yaw and pitch parameters introduced lately 
+  for pyro trigger events (note the slight difference between the definition of yaw 
+  and pan, and pitch and tilt). The drone numbering in the `.vviz` files was also
+  changed to start from 1 instead of 0. Finally, the size of the `.vviz` file is 
+  now reduced to some extent with proper rounding of inner values stored. The
+  new features of the exporter are introduced in **Skybrush Studio Server**
+  version 2.39.0.
+
 ## [4.3.0] - 2026-04-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- The `.vviz` exporter got enhanced in several ways. It received a new time offset 
-  parameter to be able to move the drone show time axis relative to the time axis 
-  of the software importing the `.vviz`. It also encodes a pan and tilt angle for
-  the pyro payloads now, based on the yaw and pitch parameters introduced lately 
-  for pyro trigger events (note the slight difference between the definition of yaw 
-  and pan, and pitch and tilt). The drone numbering in the `.vviz` files was also
-  changed to start from 1 instead of 0. Finally, the size of the `.vviz` file is 
-  now reduced to some extent with proper rounding of inner values stored. The
-  new features of the exporter are introduced in **Skybrush Studio Server**
-  version 2.39.0.
+- The `.vviz` exporter received a new time offset parameter to be able to move the
+  drone show time axis relative to the time axis of the software importing the
+  `.vviz` file. It also encodes pan and tilt angles for the pyro payloads now, based
+  on the yaw and pitch parameters introduced lately for pyro trigger events (note
+  the slight difference between the definition of yaw and pan, and pitch and tilt).
+  The drone numbering in the `.vviz` files was also changed to start from 1 instead
+  of 0. Finally, the size of the `.vviz` file is now reduced to some extent with
+  proper rounding of inner values stored. The new features of the exporter are
+  introduced in **Skybrush Studio Server** version 2.39.0.
 
 ## [4.3.0] - 2026-04-01
 

--- a/src/modules/sbstudio/plugin/operators/export_to_vviz.py
+++ b/src/modules/sbstudio/plugin/operators/export_to_vviz.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from bpy.props import BoolProperty, IntProperty, StringProperty
+from bpy.props import BoolProperty, FloatProperty, IntProperty, StringProperty
 
 from sbstudio.model.file_formats import FileFormat
 
@@ -39,6 +39,12 @@ class VVIZExportOperator(ExportOperator):
         description="Number of samples to take from light programs per second",
     )
 
+    time_offset = FloatProperty(
+        name="Time offset",
+        default=0,
+        description="Time offset to add to the output relative to Finale 3D time, in seconds",
+    )
+
     # pyro control enable/disable
     use_pyro_control = BoolProperty(
         name="Export pyro (PRO)",
@@ -62,6 +68,7 @@ class VVIZExportOperator(ExportOperator):
         layout.prop(self, "redraw")
         layout.prop(self, "output_fps")
         layout.prop(self, "light_output_fps")
+        layout.prop(self, "time_offset")
 
         layout.separator()
 
@@ -81,4 +88,5 @@ class VVIZExportOperator(ExportOperator):
             "light_output_fps": self.light_output_fps,
             "use_pyro_control": self.use_pyro_control,
             "use_yaw_control": self.use_yaw_control,
+            "time_offset": self.time_offset,
         }

--- a/src/modules/sbstudio/plugin/operators/utils.py
+++ b/src/modules/sbstudio/plugin/operators/utils.py
@@ -304,6 +304,7 @@ def export_show_to_file_using_api(
         renderer_params = {
             "fps": settings["output_fps"],
             "light_fps": settings["light_output_fps"],
+            "time_offset": settings["time_offset"],
         }
     else:
         raise RuntimeError(f"Unhandled format: {format!r}")


### PR DESCRIPTION
This PR adds a time_offset param to the .vviz exporter.

Needs new version from vviz exporter and linking that to backend, but will not crash but neglect only if that is not present