### PR TITLE
Fix/int round issues

### DIFF
--- a/src/modules/sbstudio/model/location.py
+++ b/src/modules/sbstudio/model/location.py
@@ -27,9 +27,9 @@ class ShowLocation:
     @property
     def json(self):
         """Returns the JSON representation of the show location."""
-        origin = [int(self.latitude * 1e7), int(self.longitude * 1e7)]
+        origin = [round(self.latitude * 1e7), round(self.longitude * 1e7)]
         if self.amsl is not None:
-            origin.append(int(self.amsl * 1e3))
+            origin.append(round(self.amsl * 1e3))
 
         return {
             "origin": origin,

--- a/src/modules/sbstudio/model/pyro_markers.py
+++ b/src/modules/sbstudio/model/pyro_markers.py
@@ -63,7 +63,7 @@ class PyroMarker:
 
     def is_active_at_frame(self, frame: int, fps: float) -> bool:
         """Returns whether the pyro is active at the given frame"""
-        if self.frame <= frame <= self.frame + self.payload.duration * fps:
+        if self.frame <= frame <= self.frame + round(self.payload.duration * fps):
             return True
 
         return False

--- a/src/modules/sbstudio/model/pyro_markers.py
+++ b/src/modules/sbstudio/model/pyro_markers.py
@@ -63,7 +63,7 @@ class PyroMarker:
 
     def is_active_at_frame(self, frame: int, fps: float) -> bool:
         """Returns whether the pyro is active at the given frame"""
-        if self.frame <= frame <= self.frame + round(self.payload.duration * fps):
+        if self.frame <= frame <= self.frame + self.payload.duration * fps:
             return True
 
         return False

--- a/src/modules/sbstudio/model/trajectory.py
+++ b/src/modules/sbstudio/model/trajectory.py
@@ -122,7 +122,6 @@ class Trajectory:
 
         Parameters:
             fps: the new fps value to resample the trajectories to, in [1/s]
-
         """
 
         if not self.points:

--- a/src/modules/sbstudio/model/trajectory.py
+++ b/src/modules/sbstudio/model/trajectory.py
@@ -4,7 +4,7 @@ from itertools import chain
 from operator import attrgetter
 from typing import Self
 
-from numpy import array
+from numpy import arange, array, interp
 
 from .point import Point3D, Point4D
 
@@ -28,6 +28,14 @@ class Trajectory:
     @property
     def first_time(self) -> float | None:
         return self.points[0].t if self.points else None
+
+    @property
+    def last_point(self) -> Point4D | None:
+        return self.points[-1] if self.points else None
+
+    @property
+    def last_time(self) -> float | None:
+        return self.points[-1].t if self.points else None
 
     def append(self, point: Point4D) -> None:
         """Add a point to the end of the trajectory."""
@@ -108,6 +116,33 @@ class Trajectory:
             return 0
 
         return self.points[-1].t - self.points[0].t
+
+    def resample_in_place(self, fps: float) -> Self:
+        """Resamples the trajectory to the given FPS value in-place.
+
+        Parameters:
+            fps: the new fps value to resample the trajectories to, in [1/s]
+
+        """
+
+        if not self.points:
+            return self
+        assert self.first_time is not None
+        assert self.last_time is not None
+
+        source_times = [p.t for p in self.points]
+        target_times = arange(self.first_time, self.last_time, 1 / fps)
+
+        resampled_x = interp(target_times, source_times, [p.x for p in self.points])
+        resampled_y = interp(target_times, source_times, [p.y for p in self.points])
+        resampled_z = interp(target_times, source_times, [p.z for p in self.points])
+
+        self.points = [
+            Point4D(t, x, y, z)
+            for t, x, y, z in zip(target_times, resampled_x, resampled_y, resampled_z)
+        ]
+
+        return self
 
     def shift_in_place(self, offset: Point3D) -> Self:
         """Shifts all points of the trajectory in-place.

--- a/src/modules/sbstudio/plugin/operators/add_markers_from_zipped_csv.py
+++ b/src/modules/sbstudio/plugin/operators/add_markers_from_zipped_csv.py
@@ -39,13 +39,20 @@ class AddMarkersFromZippedCSVOperator(DynamicMarkerCreationOperator, ImportHelpe
         description="Update the duration of the storyboard entry based on animation length",
     )
 
+    resample_trajectories = BoolProperty(
+        name="Resample to render FPS",
+        default=True,
+        description="Resample the imported trajectories to the render FPS value used in Blender",
+    )
+
     # List of file extensions that correspond to Skybrush CSV files
     filter_glob = StringProperty(default="*.zip", options={"HIDDEN"})
     filename_ext = ".zip"
 
     def _create_trajectories(self, context) -> dict[str, TrajectoryAndLightProgram]:
-        filepath = ensure_ext(self.filepath, self.filename_ext)
-        return parse_compressed_csv_zip(filepath)
+        filename = ensure_ext(self.filepath, self.filename_ext)
+        resample_fps = context.scene.render.fps if self.resample_trajectories else None
+        return parse_compressed_csv_zip(filename, resample_fps)
 
     def invoke(self, context, event):
         context.window_manager.fileselect_add(self)
@@ -54,12 +61,14 @@ class AddMarkersFromZippedCSVOperator(DynamicMarkerCreationOperator, ImportHelpe
 
 def parse_compressed_csv_zip(
     filename: str | IO[bytes],
+    resample_fps: float | None = None,
 ) -> dict[str, TrajectoryAndLightProgram]:
     """Parse a .zip file containing Skybrush .csv files (one file per drone,
     each containing baked animation with timestamped positions and colors).
 
     Args:
         filename: the name of the .zip input file
+        resample_fps: optional FPS value to resample imported trajectories to
 
     Returns:
         dictionary mapping the imported object names to the corresponding
@@ -114,6 +123,9 @@ def parse_compressed_csv_zip(
                     timestamps.append(t)
                     trajectory.append(Point4D(t, x, y, z))
                     light_program.append(Color4D(t, r, g, b))
+
+            if resample_fps:
+                trajectory.resample_in_place(resample_fps)
 
             # store the result only if there is at least one point, otherwise
             # there's nothing we can construct

--- a/src/modules/sbstudio/plugin/operators/add_markers_from_zipped_csv.py
+++ b/src/modules/sbstudio/plugin/operators/add_markers_from_zipped_csv.py
@@ -51,8 +51,8 @@ class AddMarkersFromZippedCSVOperator(DynamicMarkerCreationOperator, ImportHelpe
 
     def _create_trajectories(self, context) -> dict[str, TrajectoryAndLightProgram]:
         filename = ensure_ext(self.filepath, self.filename_ext)
-        resample_fps = context.scene.render.fps if self.resample_trajectories else None
-        return parse_compressed_csv_zip(filename, resample_fps)
+        output_fps = context.scene.render.fps if self.resample_trajectories else None
+        return parse_compressed_csv_zip(filename, output_fps)
 
     def invoke(self, context, event):
         context.window_manager.fileselect_add(self)
@@ -61,14 +61,14 @@ class AddMarkersFromZippedCSVOperator(DynamicMarkerCreationOperator, ImportHelpe
 
 def parse_compressed_csv_zip(
     filename: str | IO[bytes],
-    resample_fps: float | None = None,
+    output_fps: float | None = None,
 ) -> dict[str, TrajectoryAndLightProgram]:
     """Parse a .zip file containing Skybrush .csv files (one file per drone,
     each containing baked animation with timestamped positions and colors).
 
     Args:
         filename: the name of the .zip input file
-        resample_fps: optional FPS value to resample imported trajectories to
+        output_fps: optional FPS value to resample imported trajectories to
 
     Returns:
         dictionary mapping the imported object names to the corresponding
@@ -124,8 +124,8 @@ def parse_compressed_csv_zip(
                     trajectory.append(Point4D(t, x, y, z))
                     light_program.append(Color4D(t, r, g, b))
 
-            if resample_fps:
-                trajectory.resample_in_place(resample_fps)
+            if output_fps:
+                trajectory.resample_in_place(output_fps)
 
             # store the result only if there is at least one point, otherwise
             # there's nothing we can construct

--- a/src/modules/sbstudio/plugin/operators/add_markers_from_zipped_dss.py
+++ b/src/modules/sbstudio/plugin/operators/add_markers_from_zipped_dss.py
@@ -51,9 +51,11 @@ class AddMarkersFromZippedDSSOperator(DynamicMarkerCreationOperator, ImportHelpe
         from sbstudio.plugin.api import call_api_from_blender_operator
 
         filename = ensure_ext(self.filepath, self.filename_ext)
-        resample_fps = context.scene.render.fps if self.resample_trajectories else None
+        output_fps = context.scene.render.fps if self.resample_trajectories else None
         with call_api_from_blender_operator(self, "import DSS") as api:
-            return parse_compressed_dss_zip(filename, context, api, resample_fps)
+            return parse_compressed_dss_zip(
+                filename, context, api, output_fps=output_fps
+            )
 
     def invoke(self, context, event):
         context.window_manager.fileselect_add(self)
@@ -64,7 +66,8 @@ def parse_compressed_dss_zip(
     filename: str,
     context,
     api: SkybrushStudioAPI,
-    resample_fps: float | None = None,
+    *,
+    output_fps: float | None = None,
 ) -> dict[str, TrajectoryAndLightProgram]:
     """Parse a .zip file containing DSS PATH/PATH3 files (one file per drone,
     each containing baked animation with timestamped positions and colors),
@@ -74,7 +77,7 @@ def parse_compressed_dss_zip(
         filename: the name of the .zip input file
         context: the Blender context
         api: the Skybrush Studio API object to call for show file format conversion
-        resample_fps: optional FPS value to resample imported trajectories to
+        output_fps: optional FPS value to resample imported trajectories to
 
     Returns:
         dictionary mapping the imported object names to the corresponding
@@ -102,6 +105,6 @@ def parse_compressed_dss_zip(
     )
 
     log.info("Parsing CSV files...")
-    result = parse_compressed_csv_zip(BytesIO(show_data), resample_fps)
+    result = parse_compressed_csv_zip(BytesIO(show_data), output_fps)
 
     return result

--- a/src/modules/sbstudio/plugin/operators/add_markers_from_zipped_dss.py
+++ b/src/modules/sbstudio/plugin/operators/add_markers_from_zipped_dss.py
@@ -37,6 +37,12 @@ class AddMarkersFromZippedDSSOperator(DynamicMarkerCreationOperator, ImportHelpe
         description="Update the duration of the storyboard entry based on animation length",
     )
 
+    resample_trajectories = BoolProperty(
+        name="Resample to render FPS",
+        default=True,
+        description="Resample the imported trajectories to the render FPS value used in Blender",
+    )
+
     # List of file extensions that correspond to DSS files
     filter_glob = StringProperty(default="*.zip", options={"HIDDEN"})
     filename_ext = ".zip"
@@ -44,9 +50,10 @@ class AddMarkersFromZippedDSSOperator(DynamicMarkerCreationOperator, ImportHelpe
     def _create_trajectories(self, context) -> dict[str, TrajectoryAndLightProgram]:
         from sbstudio.plugin.api import call_api_from_blender_operator
 
-        filepath = ensure_ext(self.filepath, self.filename_ext)
+        filename = ensure_ext(self.filepath, self.filename_ext)
+        resample_fps = context.scene.render.fps if self.resample_trajectories else None
         with call_api_from_blender_operator(self, "import DSS") as api:
-            return parse_compressed_dss_zip(filepath, context, api)
+            return parse_compressed_dss_zip(filename, context, api, resample_fps)
 
     def invoke(self, context, event):
         context.window_manager.fileselect_add(self)
@@ -54,7 +61,10 @@ class AddMarkersFromZippedDSSOperator(DynamicMarkerCreationOperator, ImportHelpe
 
 
 def parse_compressed_dss_zip(
-    filename: str, context, api: SkybrushStudioAPI
+    filename: str,
+    context,
+    api: SkybrushStudioAPI,
+    resample_fps: float | None = None,
 ) -> dict[str, TrajectoryAndLightProgram]:
     """Parse a .zip file containing DSS PATH/PATH3 files (one file per drone,
     each containing baked animation with timestamped positions and colors),
@@ -64,6 +74,7 @@ def parse_compressed_dss_zip(
         filename: the name of the .zip input file
         context: the Blender context
         api: the Skybrush Studio API object to call for show file format conversion
+        resample_fps: optional FPS value to resample imported trajectories to
 
     Returns:
         dictionary mapping the imported object names to the corresponding
@@ -91,6 +102,6 @@ def parse_compressed_dss_zip(
     )
 
     log.info("Parsing CSV files...")
-    result = parse_compressed_csv_zip(BytesIO(show_data))
+    result = parse_compressed_csv_zip(BytesIO(show_data), resample_fps)
 
     return result

--- a/src/modules/sbstudio/plugin/operators/base.py
+++ b/src/modules/sbstudio/plugin/operators/base.py
@@ -315,7 +315,7 @@ class DynamicMarkerCreationOperator(FormationOperator):
         # update storyboard duration based on animation data
         if bool(getattr(self, "update_duration", False)) and storyboard_entry:
             duration = (
-                round(max(trajectory.duration for trajectory in trajectories) * fps) + 1
+                int(max(trajectory.duration for trajectory in trajectories) * fps) + 1
             )
             storyboard_entry.duration = duration
 
@@ -361,7 +361,7 @@ class DynamicMarkerCreationOperator(FormationOperator):
         ]
         if light_effects and light_programs:
             duration = (
-                round(
+                int(
                     (light_programs[0].colors[-1].t - light_programs[0].colors[0].t)
                     * fps
                 )

--- a/src/modules/sbstudio/plugin/operators/base.py
+++ b/src/modules/sbstudio/plugin/operators/base.py
@@ -315,7 +315,7 @@ class DynamicMarkerCreationOperator(FormationOperator):
         # update storyboard duration based on animation data
         if bool(getattr(self, "update_duration", False)) and storyboard_entry:
             duration = (
-                int(max(trajectory.duration for trajectory in trajectories) * fps) + 1
+                round(max(trajectory.duration for trajectory in trajectories) * fps) + 1
             )
             storyboard_entry.duration = duration
 
@@ -336,7 +336,7 @@ class DynamicMarkerCreationOperator(FormationOperator):
 
             # add keypoints to f-curves in low level mode
             t0 = trajectory.points[0].t
-            frames = [frame_start + int((p.t - t0) * fps) for p in trajectory.points]
+            frames = [frame_start + round((p.t - t0) * fps) for p in trajectory.points]
             values_x = [p.x for p in trajectory.points]
             values_y = [p.y for p in trajectory.points]
             values_z = [p.z for p in trajectory.points]
@@ -361,7 +361,7 @@ class DynamicMarkerCreationOperator(FormationOperator):
         ]
         if light_effects and light_programs:
             duration = (
-                int(
+                round(
                     (light_programs[0].colors[-1].t - light_programs[0].colors[0].t)
                     * fps
                 )
@@ -390,7 +390,7 @@ class DynamicMarkerCreationOperator(FormationOperator):
                 t0 = color.t
                 j_last = 0
                 for next_color in light_program.colors[1:]:
-                    j_next = int((next_color.t - t0) * fps)
+                    j_next = round((next_color.t - t0) * fps)
                     pixels.extend(list(color.as_vector()) * (j_next - j_last))
                     j_last = j_next
                     color = next_color

--- a/src/modules/sbstudio/plugin/operators/land.py
+++ b/src/modules/sbstudio/plugin/operators/land.py
@@ -182,7 +182,7 @@ class LandOperator(StoryboardOperator):
             durations = [diff / self.velocity for diff in diffs]
 
         delays = [int(ceil(delay * fps)) for delay in delays]
-        durations = [int(floor(duration * fps)) for duration in durations]
+        durations = [int(ceil(duration * fps)) for duration in durations]
         max_duration = max(
             delay + duration for delay, duration in zip(delays, durations)
         )

--- a/src/modules/sbstudio/plugin/operators/return_to_home.py
+++ b/src/modules/sbstudio/plugin/operators/return_to_home.py
@@ -262,7 +262,7 @@ class ReturnToHomeOperator(StoryboardOperator):
         # Calculate RTH duration from max distance to travel and the
         # average velocity
         max_distance = max(diffs)
-        rth_duration = ceil((max_distance / self.velocity) * fps)
+        rth_duration = int(ceil((max_distance / self.velocity) * fps))
 
         # Extend the duration of the last formation to the frame where we want
         # to start the RTH maneuver
@@ -375,7 +375,7 @@ class ReturnToHomeOperator(StoryboardOperator):
                     )
                 )
             for point in path_points:
-                frame = int(self.start_frame + point[0] * fps)
+                frame = round(self.start_frame + point[0] * fps)
                 keyframes = (
                     insert[0](frame, point[1]),
                     insert[1](frame, point[2]),

--- a/src/modules/sbstudio/plugin/operators/takeoff.py
+++ b/src/modules/sbstudio/plugin/operators/takeoff.py
@@ -199,7 +199,7 @@ class TakeoffOperator(StoryboardOperator):
         # Calculate takeoff durations from distances to travel and the
         # average velocity
         fps = context.scene.render.fps
-        takeoff_durations = [ceil((diff / self.velocity) * fps) for diff in diffs]
+        takeoff_durations = [int(ceil((diff / self.velocity) * fps)) for diff in diffs]
 
         # We ensure that drones arrive at the same time, so calculate the
         # takeoff delays for those drones that take off to lower altitudes

--- a/src/modules/sbstudio/plugin/utils/pyro_markers.py
+++ b/src/modules/sbstudio/plugin/utils/pyro_markers.py
@@ -137,7 +137,7 @@ def update_pyro_particles_of_object(ob: Object) -> None:
                 marker.payload.duration * 50
             )  # 50 particles/sec
             particle_settings.frame_start = marker.frame
-            particle_settings.frame_end = int(
+            particle_settings.frame_end = round(
                 marker.frame + (marker.payload.duration + randint(-4, 4)) * fps
             )
             particle_settings.lifetime = randint(1 * fps, 2 * fps)


### PR DESCRIPTION
This PR hopefully fixes some int discretization and rounding errors throughout the entire codebase where `int()` has been used instead of `round()`, especially in the context of converting timestamps to frames. 

The issue was detected by Discord user @jonas in the context of having annoying acceleration peaks when importing .csv or .path files as a dynamic formation. However, during tests I also realized that the acceleration peaks might be caused by the inconsistent FPS value of the sampled input and the used render FPS so I added an option to resample imported trajectories to the final FPS on DSS path/path3 and CSV importers. This resolves the issue in my tests.
