### PR TITLE
WIP: fix: ensure min distance during layered takeoff

### DIFF
--- a/src/modules/sbstudio/plugin/operators/takeoff.py
+++ b/src/modules/sbstudio/plugin/operators/takeoff.py
@@ -23,6 +23,7 @@ from sbstudio.plugin.operators.recalculate_transitions import (
     recalculate_transitions,
 )
 from sbstudio.plugin.utils.evaluator import create_position_evaluator
+from sbstudio.plugin.utils.transition import get_bezier_inverse_smoothstep
 
 from .base import StoryboardOperator
 
@@ -196,14 +197,32 @@ class TakeoffOperator(StoryboardOperator):
             )
             return False
 
-        # Calculate takeoff durations from distances to travel and the
-        # average velocity
+        # Since Blender uses Bezier interpolation on the takeoff segment, we need to
+        # calculate explicitly when the layer above reaches the layer distance for each
+        # drone and use that value as the delay for its own takeoff, reverse-recursively
         fps = context.scene.render.fps
-        takeoff_durations = [int(ceil((diff / self.velocity) * fps)) for diff in diffs]
+        layer_indices = [
+            round((diff - self.altitude) / self.altitude_shift) for diff in diffs
+        ]
+        takeoff_durations = [0.0] * len(layer_indices)
+        takeoff_duration = 0
+        for layer_index in range(max(layer_indices) + 1):
+            diff = layer_index * self.altitude_shift + self.altitude
+            if layer_index == 0:
+                # if it is the lowest layer, calculate takeoff durations directly
+                takeoff_duration = int(ceil((diff / self.velocity) * fps))
+            else:
+                # calculate delay needed for current layer to let layer above
+                # reach altitude shift
+                x = get_bezier_inverse_smoothstep(self.altitude_shift, diff)
+                takeoff_duration += int(ceil(x / (1 - x) * takeoff_duration))
+            # change takeoff duration of drones in the given layer
+            for i in range(len(drones)):
+                if layer_indices[i] == layer_index:
+                    takeoff_durations[i] = takeoff_duration
 
         # We ensure that drones arrive at the same time, so calculate the
         # takeoff delays for those drones that take off to lower altitudes
-        takeoff_duration = max(takeoff_durations)
         delays = [takeoff_duration - d for d in takeoff_durations]
 
         # Calculate when the takeoff should end

--- a/src/modules/sbstudio/plugin/utils/transition.py
+++ b/src/modules/sbstudio/plugin/utils/transition.py
@@ -66,6 +66,55 @@ def find_transition_constraint_between(
     return None
 
 
+def get_bezier_inverse_smoothstep(
+    x: float, length: float, *, iterations: int = 20
+) -> float:
+    """Returns the (approximated) inverse smoothstep function of the standard
+    cubic Bezier interpolation used by Blender as the Easing function (3u^2-2u^3).
+
+    The approximation is used by a simple binary search.
+
+    Args:
+        x: the partial distance of the transition at which we query
+        length: the total length of the transition
+
+    Returns:
+        the inverse smoothstep function of the cubic Bezier curve
+    """
+    r = x / length
+
+    lo, hi = 0.0, 1.0
+
+    for _ in range(iterations):
+        mid = (lo + hi) / 2
+        s = 3 * mid * mid - 2 * mid * mid * mid
+
+        if s < r:
+            lo = mid
+        else:
+            hi = mid
+
+    return (lo + hi) / 2
+
+
+def get_time_of_partial_bezier_transition(x, length: float, speed: float) -> float:
+    """Returns the time needed to travel only part of a transition, assuming
+    standard cubic Bezier interpolation of the transition.
+
+    Args:
+        x: the partial distance at which we query the time when it is reached
+        length: the total length of the transition
+        speed: the averate speed of the transition
+
+    Returns:
+        the time needed to reach the given point as part of the transition
+    """
+    if x < 0 or x > length or speed <= 0:
+        raise ValueError("Invalid input parameters")
+
+    return (length / speed) * get_bezier_inverse_smoothstep(x, length)
+
+
 def is_transition_constraint(constraint: Constraint) -> bool:
     """Returns whether the given constraint object is a transition constraint,
     judging from its name and type.


### PR DESCRIPTION
This PR is preliminary. I was trying to target the problem that min distance during layered takeoff is not kept as we assume linear motion while calculating the delays between layers but in reality Blender plans with Bezier motion and this the layers above are still too close when a given layer takes off. 

The solution presented in this PR solves the issue, but results in very long takeoffs which is not good either. Best would be to abandon Bezier interpolation during takeoff and do a linear segment until everyone takes off and then a common slowdown with limited acc. Or something.

Anyhow, I opened the PR for discussions.