### PR TITLE
Simplifying the “cone” template

### DIFF
--- a/src/modules/sbstudio/plugin/meshes.py
+++ b/src/modules/sbstudio/plugin/meshes.py
@@ -42,7 +42,7 @@ def create_cone(
             bm,
             cap_ends=True,
             cap_tris=True,
-            segments=32,
+            segments=12,
             radius1=radius,
             depth=radius * 2,
             matrix=Matrix.Rotation(radians(90), 3, "Y"),


### PR DESCRIPTION
Fewer vertices when creating drones using the “cone” template. Fewer vertices in the viewport mean fewer calculations when redrawing on screen.

It's a simple change that has a very minimal impact on performance, but when we're talking about 4,000 drones, we go from 132,000 vertices to 52,000.

At Pyroemotions, this is how we usually work; viewing formations in the viewport doesn't provide any visual, aesthetic, or understanding impact.