### PR TITLE
WIP: Feat/takeoff pods

### DIFF
--- a/src/modules/sbstudio/plugin/constants.py
+++ b/src/modules/sbstudio/plugin/constants.py
@@ -72,7 +72,7 @@ class Collections:
     FORMATIONS: ClassVar[str] = "Formations"
     """Name of the collection that holds the formations"""
 
-    TAKEOFF_PODS: ClassVar[str] = "Takeoff pods"
+    TAKEOFF_PODS: ClassVar[str] = "Takeoff Pods"
     """Name of the collection that holds predefined takeoff pod layouts"""
 
     TEMPLATES: ClassVar[str] = "Templates"

--- a/src/modules/sbstudio/plugin/constants.py
+++ b/src/modules/sbstudio/plugin/constants.py
@@ -11,7 +11,9 @@ from typing import (
 )
 
 import bpy
-from bpy.types import Collection
+from bpy.types import Collection, Object
+
+from sbstudio.plugin.objects import create_object
 
 from .materials import create_colored_material, create_glowing_material
 from .meshes import create_cone, create_icosphere
@@ -70,6 +72,9 @@ class Collections:
     FORMATIONS: ClassVar[str] = "Formations"
     """Name of the collection that holds the formations"""
 
+    TAKEOFF_PODS: ClassVar[str] = "Takeoff pods"
+    """Name of the collection that holds predefined takeoff pod layouts"""
+
     TEMPLATES: ClassVar[str] = "Templates"
     """Name of the collection that holds the object templates"""
 
@@ -108,6 +113,18 @@ class Collections:
     @classmethod
     def find_formations(cls, *, create: bool = True):
         return cls._find(cls.FORMATIONS, create=create)
+
+    @classmethod
+    @overload
+    def find_takeoff_pods(cls, *, create: Literal[True] = True) -> Collection: ...
+
+    @classmethod
+    @overload
+    def find_takeoff_pods(cls, *, create: bool) -> Collection | None: ...
+
+    @classmethod
+    def find_takeoff_pods(cls, *, create: bool = True):
+        return cls._find(cls.TAKEOFF_PODS, create=create)
 
     @classmethod
     @overload
@@ -208,6 +225,87 @@ class Formations:
             )
         else:
             return None
+
+
+class TakeoffPods:
+    DRONEMAX: ClassVar[str] = "DroneMax"
+    """Name of the DroneMax takeoff pod object, containing 8 vertices."""
+
+    @classmethod
+    def create_takeoff_pods(cls) -> None:
+        """Creates the predefined takeoff pod template objects."""
+        takeoff_pods = Collections.find_takeoff_pods()
+        coll = takeoff_pods.objects
+
+        for name, factory in zip(
+            [
+                cls.DRONEMAX,
+                # TODO: add more templates from more manufacturers
+            ],
+            [
+                cls._create_dronemax_pod,
+                # TODO: add more templates from more manufacturers
+            ],
+            strict=True,
+        ):
+            ensure_object_exists_in_collection(coll, name, factory)
+
+    @classmethod
+    def find_pod(cls, name: str) -> Object | None:
+        """Returns the mesh object associated with the given takeoff pod,
+        or `None` if no such takeoff pod template exists.
+
+        Args:
+            name: the name of the pod to search for
+
+        Returns:
+            the pod object with the given name
+        """
+        takeoff_pods = Collections.find_takeoff_pods(create=False)
+        if takeoff_pods:
+            coll = takeoff_pods.objects
+            return get_object_in_collection(coll, name, default=None)
+        else:
+            return None
+
+    @staticmethod
+    def _create_dronemax_pod():
+        verts = [
+            (-0.18, -0.545, 0.0),
+            (0.18, -0.545, 0.0),
+            (-0.18, -0.215, 0.0),
+            (0.18, -0.215, 0.0),
+            (-0.18, 0.165, 0.0),
+            (0.18, 0.165, 0.0),
+            (-0.18, 0.495, 0.0),
+            (0.18, 0.495, 0.0),
+        ]
+        edges = []
+        faces = []
+        mesh = bpy.data.meshes.new(TakeoffPods.DRONEMAX)
+        mesh.from_pydata(verts, edges, faces)
+        mesh.update()
+        object = create_object(TakeoffPods.DRONEMAX, mesh)
+        TakeoffPods._prepare_new_pod_object(object)
+        return object
+
+    @staticmethod
+    def _prepare_new_pod_object(object) -> None:
+        """Prepares a new pod object for the takeoff pods collection."""
+        # We remove the object from all collections it is in.
+        for collection in bpy.data.collections:
+            if object.name in collection.objects:
+                collection.objects.unlink(object)
+        if object.name in bpy.context.scene.collection.objects:
+            bpy.context.scene.collection.objects.unlink(object)
+
+        # Hide the object from the viewport and the render
+        object.hide_viewport = True
+        object.hide_select = True
+        object.hide_render = True
+
+        # Make sure that the object is not selected
+        object.select_set(False)
 
 
 class Templates:

--- a/src/modules/sbstudio/plugin/constants.py
+++ b/src/modules/sbstudio/plugin/constants.py
@@ -228,8 +228,11 @@ class Formations:
 
 
 class TakeoffPods:
-    DRONEMAX: ClassVar[str] = "DroneMax"
-    """Name of the DroneMax takeoff pod object, containing 8 vertices."""
+    DRONEMAX: ClassVar[str] = "DroneMax (2x4)"
+    """Name of the DroneMax takeoff pod object, containing 2x4 vertices."""
+
+    LIGHT_DYNAMIX_PIXEL: ClassVar[str] = "LightDynamix Pixel (2x3)"
+    """Name of the LightDynamix Pixel takeoff pod object, containing 2x3 vertices."""
 
     @classmethod
     def create_takeoff_pods(cls) -> None:
@@ -240,10 +243,12 @@ class TakeoffPods:
         for name, factory in zip(
             [
                 cls.DRONEMAX,
+                cls.LIGHT_DYNAMIX_PIXEL,
                 # TODO: add more templates from more manufacturers
             ],
             [
                 cls._create_dronemax_pod,
+                cls._create_light_dynamix_pixel_pod,
                 # TODO: add more templates from more manufacturers
             ],
             strict=True,
@@ -270,7 +275,7 @@ class TakeoffPods:
 
     @staticmethod
     def _create_dronemax_pod():
-        verts = [
+        vertices = [
             (-0.18, -0.545, 0.0),
             (0.18, -0.545, 0.0),
             (-0.18, -0.215, 0.0),
@@ -280,18 +285,36 @@ class TakeoffPods:
             (-0.18, 0.495, 0.0),
             (0.18, 0.495, 0.0),
         ]
-        edges = []
-        faces = []
-        mesh = bpy.data.meshes.new(TakeoffPods.DRONEMAX)
-        mesh.from_pydata(verts, edges, faces)
-        mesh.update()
-        object = create_object(TakeoffPods.DRONEMAX, mesh)
-        TakeoffPods._prepare_new_pod_object(object)
-        return object
+        return TakeoffPods._prepare_new_pod_object(TakeoffPods.DRONEMAX, vertices)
 
     @staticmethod
-    def _prepare_new_pod_object(object) -> None:
-        """Prepares a new pod object for the takeoff pods collection."""
+    def _create_light_dynamix_pixel_pod():
+        vertices = [
+            (-0.175, -0.35, 0.0),
+            (0.175, -0.35, 0.0),
+            (-0.175, 0, 0.0),
+            (0.175, 0, 0.0),
+            (-0.175, 0.35, 0.0),
+            (0.175, 0.35, 0.0),
+        ]
+        return TakeoffPods._prepare_new_pod_object(
+            TakeoffPods.LIGHT_DYNAMIX_PIXEL, vertices
+        )
+
+    @staticmethod
+    def _prepare_new_pod_object(
+        name: str, vertices: list[tuple[float, float, float]]
+    ) -> Object:
+        """Prepares a new pod object from vertices for the takeoff pods collection."""
+
+        # create object from raw vertices
+        edges = []
+        faces = []
+        mesh = bpy.data.meshes.new(name)
+        mesh.from_pydata(vertices, edges, faces)
+        mesh.update()
+        object = create_object(name, mesh)
+
         # We remove the object from all collections it is in.
         for collection in bpy.data.collections:
             if object.name in collection.objects:
@@ -306,6 +329,8 @@ class TakeoffPods:
 
         # Make sure that the object is not selected
         object.select_set(False)
+
+        return object
 
 
 class Templates:

--- a/src/modules/sbstudio/plugin/operators/create_takeoff_grid.py
+++ b/src/modules/sbstudio/plugin/operators/create_takeoff_grid.py
@@ -390,9 +390,6 @@ class CreateTakeoffGridOperator(Operator):
         return {"FINISHED"}
 
     def invoke(self, context, event):
-        # make sure predefined takeoff pods are created before we
-        # invoke the takeoff grid operator
-        TakeoffPods.create_takeoff_pods()
         return context.window_manager.invoke_props_dialog(self)
         # The code below is used to trigger the settings panel in the lower
         # left hand corner, see:

--- a/src/modules/sbstudio/plugin/operators/create_takeoff_grid.py
+++ b/src/modules/sbstudio/plugin/operators/create_takeoff_grid.py
@@ -1,8 +1,9 @@
-from math import ceil
+from math import ceil, radians
 
 import bpy
 from bpy.props import BoolProperty, FloatProperty, IntProperty, StringProperty
 from bpy.types import Operator
+from mathutils import Matrix
 from numpy import array, column_stack, mgrid, repeat, tile, zeros
 
 from sbstudio.model.types import Coordinate3D
@@ -63,6 +64,7 @@ def create_points_of_takeoff_grid(
     intra_slot_spacing_row: float = 0.5,
     intra_slot_spacing_col: float = 0.5,
     takeoff_pod: str = "",
+    takeoff_pod_rotation: float = 0,
 ) -> list[Coordinate3D]:
     """Creates the points of a takeoff grid centered at the given coordinate.
 
@@ -77,6 +79,7 @@ def create_points_of_takeoff_grid(
         intra_slot_spacing_row: the row spacing within a single slot of the grid
         intra_slot_spacing_col: the column spacing within a single slot of the grid
         takeoff_pod: optional takeoff pod mesh name to use at each position as a subgrid
+        takeoff_pod_rotation: optional rotation of the takeoff pod around axis Z, in [rad]
 
     Returns:
         the list of points in the grid
@@ -127,7 +130,10 @@ def create_points_of_takeoff_grid(
     if takeoff_pod and (pod_obj := TakeoffPods.find_pod(takeoff_pod)) is not None:
         vertices = get_vertices_of_object(pod_obj)
         num_drones_per_pod = len(vertices)
-        slot_template = array([v.co[:] for v in vertices])
+        rotation_matrix = Matrix.Rotation(takeoff_pod_rotation, 3, "Z")
+        slot_template = array(
+            [(rotation_matrix @ v.co)[:] for v in vertices], dtype=float
+        )
 
         grid = column_stack((xs, ys, zs))
         coords = repeat(grid, num_drones_per_pod, axis=0)
@@ -281,6 +287,16 @@ class CreateTakeoffGridOperator(Operator):
         update=_handle_takeoff_pod_change,
     )
 
+    takeoff_pod_rotation = FloatProperty(
+        name="Pod rotation",
+        description="Rotation of the takeoff pod around the vertical axis",
+        default=radians(0),
+        soft_min=radians(-180),
+        soft_max=radians(180),
+        step=100,  # Note that while min and max are expressed in radians, step must be expressed in 100*degrees to work properly
+        unit="ROTATION",
+    )
+
     use_separate_column_spacing = BoolProperty(
         name="Use seperate column spacing",
         default=False,
@@ -365,6 +381,8 @@ class CreateTakeoffGridOperator(Operator):
             pods = Collections.find_takeoff_pods(create=False)
             if pods:
                 layout.prop_search(self, "takeoff_pod", pods, "objects")
+                if self.takeoff_pod:
+                    layout.prop(self, "takeoff_pod_rotation")
 
     def execute(self, context):
         # This code path is invoked after an undo-redo
@@ -404,6 +422,7 @@ class CreateTakeoffGridOperator(Operator):
             intra_slot_spacing_row=self.intra_slot_spacing_row,
             intra_slot_spacing_col=self.intra_slot_spacing_col,
             takeoff_pod=self.takeoff_pod,
+            takeoff_pod_rotation=self.takeoff_pod_rotation,
         )[: self.drones]
 
         settings = context.scene.skybrush.settings

--- a/src/modules/sbstudio/plugin/operators/create_takeoff_grid.py
+++ b/src/modules/sbstudio/plugin/operators/create_takeoff_grid.py
@@ -1,3 +1,5 @@
+from math import ceil
+
 import bpy
 from bpy.props import BoolProperty, FloatProperty, IntProperty, StringProperty
 from bpy.types import Operator
@@ -143,6 +145,13 @@ def _get_num_drones_per_pod(operator):
 
     # backwards compatibility
     return 1
+
+
+def _get_number_of_pods(operator):
+    if hasattr(operator, "takeoff_pod") and operator.takeoff_pod:
+        return ceil(operator.drones / _get_num_drones_per_pod(operator))
+
+    return 0
 
 
 def _get_num_drones_per_slot(operator):
@@ -330,7 +339,13 @@ class CreateTakeoffGridOperator(Operator):
         # general settings
         layout.prop(self, "rows")
         layout.prop(self, "columns")
-        layout.prop(self, "drones")
+        num_pods = _get_number_of_pods(self)
+        if num_pods > 0:
+            row = layout.row()
+            row.prop(self, "drones")
+            row.label(text=f"  ({num_pods} pods)")
+        else:
+            layout.prop(self, "drones")
         layout.prop(self, "spacing")
         layout.prop(self, "use_advanced_settings")
         # advanced settings

--- a/src/modules/sbstudio/plugin/operators/create_takeoff_grid.py
+++ b/src/modules/sbstudio/plugin/operators/create_takeoff_grid.py
@@ -1,14 +1,15 @@
 import bpy
-from bpy.props import BoolProperty, FloatProperty, IntProperty
+from bpy.props import BoolProperty, FloatProperty, IntProperty, StringProperty
 from bpy.types import Operator
 from numpy import array, column_stack, mgrid, repeat, tile, zeros
 
 from sbstudio.model.types import Coordinate3D
 from sbstudio.plugin.colors import create_keyframe_for_color_of_drone
-from sbstudio.plugin.constants import Collections, Formations, Templates
+from sbstudio.plugin.constants import Collections, Formations, TakeoffPods, Templates
 from sbstudio.plugin.materials import get_material_for_pyro
 from sbstudio.plugin.model.formation import add_points_to_formation, create_formation
 from sbstudio.plugin.model.storyboard import StoryboardEntryPurpose, get_storyboard
+from sbstudio.plugin.objects import get_vertices_of_object
 from sbstudio.plugin.operators.detach_materials_from_template import (
     detach_pyro_material_from_drone_template,
 )
@@ -59,6 +60,7 @@ def create_points_of_takeoff_grid(
     spacing_col: float = 1,
     intra_slot_spacing_row: float = 0.5,
     intra_slot_spacing_col: float = 0.5,
+    takeoff_pod: str = "",
 ) -> list[Coordinate3D]:
     """Creates the points of a takeoff grid centered at the given coordinate.
 
@@ -72,6 +74,7 @@ def create_points_of_takeoff_grid(
         spacing_col: the column spacing of points in the grid
         intra_slot_spacing_row: the row spacing within a single slot of the grid
         intra_slot_spacing_col: the column spacing within a single slot of the grid
+        takeoff_pod: optional takeoff pod mesh name to use at each position as a subgrid
 
     Returns:
         the list of points in the grid
@@ -118,7 +121,28 @@ def create_points_of_takeoff_grid(
         coords += tile(template, (columns * rows, 1))
         xs, ys, zs = coords[:, 0], coords[:, 1], coords[:, 2]
 
+    # Finally, multiple the entire grid with the takeoff pods
+    if takeoff_pod and (pod_obj := TakeoffPods.find_pod(takeoff_pod)) is not None:
+        vertices = get_vertices_of_object(pod_obj)
+        num_drones_per_pod = len(vertices)
+        slot_template = array([v.co[:] for v in vertices])
+
+        grid = column_stack((xs, ys, zs))
+        coords = repeat(grid, num_drones_per_pod, axis=0)
+        coords += tile(slot_template, (len(grid), 1))
+        xs, ys, zs = coords[:, 0], coords[:, 1], coords[:, 2]
+
     return list(zip(xs, ys, zs))
+
+
+def _get_num_drones_per_pod(operator):
+    if hasattr(operator, "takeoff_pod"):
+        pod_obj = TakeoffPods.find_pod(operator.takeoff_pod)
+        if pod_obj is not None:
+            return max(1, len(get_vertices_of_object(pod_obj)))
+
+    # backwards compatibility
+    return 1
 
 
 def _get_num_drones_per_slot(operator):
@@ -144,7 +168,13 @@ def _get_num_drones_per_slot_col(operator):
 
 
 def _get_max_possible_drone_count(operator):
-    return operator.rows * operator.columns * _get_num_drones_per_slot(operator)
+
+    return (
+        operator.rows
+        * operator.columns
+        * _get_num_drones_per_slot(operator)
+        * _get_num_drones_per_pod(operator)
+    )
 
 
 def _ensure_rows_columns_and_counts_consistent(operator, context):
@@ -166,6 +196,10 @@ def _handle_drone_count_change(operator, context):
 
 
 def _handle_drones_per_slot_change(operator, context):
+    _ensure_rows_columns_and_counts_consistent(operator, context)
+
+
+def _handle_takeoff_pod_change(operator, context):
     _ensure_rows_columns_and_counts_consistent(operator, context)
 
 
@@ -230,6 +264,13 @@ class CreateTakeoffGridOperator(Operator):
     )
 
     # advanced parameters below
+
+    takeoff_pod = StringProperty(
+        name="Takeoff pod",
+        description="Select a predefined takeoff pod template to use at each point of the main grid",
+        default="",
+        update=_handle_takeoff_pod_change,
+    )
 
     use_separate_column_spacing = BoolProperty(
         name="Use seperate column spacing",
@@ -305,6 +346,10 @@ class CreateTakeoffGridOperator(Operator):
             layout.prop(self, "drones_per_slot_col")
             layout.prop(self, "intra_slot_spacing_row")
             layout.prop(self, "intra_slot_spacing_col")
+            # takeoff pods
+            pods = Collections.find_takeoff_pods(create=False)
+            if pods:
+                layout.prop_search(self, "takeoff_pod", pods, "objects")
 
     def execute(self, context):
         # This code path is invoked after an undo-redo
@@ -312,6 +357,9 @@ class CreateTakeoffGridOperator(Operator):
         return {"FINISHED"}
 
     def invoke(self, context, event):
+        # make sure predefined takeoff pods are created before we
+        # invoke the takeoff grid operator
+        TakeoffPods.create_takeoff_pods()
         return context.window_manager.invoke_props_dialog(self)
         # The code below is used to trigger the settings panel in the lower
         # left hand corner, see:
@@ -340,6 +388,7 @@ class CreateTakeoffGridOperator(Operator):
             else self.spacing,
             intra_slot_spacing_row=self.intra_slot_spacing_row,
             intra_slot_spacing_col=self.intra_slot_spacing_col,
+            takeoff_pod=self.takeoff_pod,
         )[: self.drones]
 
         settings = context.scene.skybrush.settings

--- a/src/modules/sbstudio/plugin/operators/prepare.py
+++ b/src/modules/sbstudio/plugin/operators/prepare.py
@@ -1,6 +1,6 @@
 from bpy.types import Operator
 
-from sbstudio.plugin.constants import Collections
+from sbstudio.plugin.constants import Collections, TakeoffPods
 from sbstudio.plugin.objects import link_object_to_scene
 from sbstudio.plugin.state import get_file_specific_state
 
@@ -11,11 +11,12 @@ class PrepareSceneOperator(Operator):
     """Blender operator that prepares a Blender file to be used with
     Skybrush Studio for Blender.
 
-    This involves:
+    This involves creating the standard "Drones", "Formations", "Takeoff pods"
+    and "Templates" collections if they do not exist yet, and generating the
+    predefined takeoff pods.
 
-    * creating the standard "Drones" and "Formations" collections if they do not
-      exist yet
-    * creating a drone template and putting it in the "Templates" collection
+    Note that the drone template is not created here yet, only on takeoff grid
+    creation later, as it might depend on some user-specified settings.
     """
 
     bl_idname = "skybrush.prepare"
@@ -28,11 +29,16 @@ class PrepareSceneOperator(Operator):
         # Initialize collections
         drones = Collections.find_drones()
         formations = Collections.find_formations()
+        takeoff_pods = Collections.find_takeoff_pods()
         templates = Collections.find_templates()
 
         link_object_to_scene(drones, allow_nested=True)
         link_object_to_scene(formations, allow_nested=True)
+        link_object_to_scene(takeoff_pods, allow_nested=True)
         link_object_to_scene(templates, allow_nested=True)
+
+        # generate takeoff pods (if they are not generated already)
+        TakeoffPods.create_takeoff_pods()
 
         # Note that we do not create the drone template here yet as
         # its size might depend on later takeoff grid parameters

--- a/src/modules/sbstudio/plugin/tasks/initialization.py
+++ b/src/modules/sbstudio/plugin/tasks/initialization.py
@@ -91,9 +91,8 @@ def setup_takeoff_pods(*args):
     can add their own pods or select from predefined ones.
     """
     takeoff_pods = Collections.find_takeoff_pods(create=True)
-    scene = bpy.context.scene
-    if takeoff_pods and scene:
-        link_object_to_scene(takeoff_pods, scene=scene, allow_nested=True)
+    if takeoff_pods:
+        link_object_to_scene(takeoff_pods, allow_nested=True)
         TakeoffPods.create_takeoff_pods()
 
 

--- a/src/modules/sbstudio/plugin/tasks/initialization.py
+++ b/src/modules/sbstudio/plugin/tasks/initialization.py
@@ -4,7 +4,8 @@ from random import randint
 
 import bpy
 
-from sbstudio.plugin.constants import RANDOM_SEED_MAX, Collections
+from sbstudio.plugin.constants import RANDOM_SEED_MAX, Collections, TakeoffPods
+from sbstudio.plugin.objects import link_object_to_scene
 from sbstudio.plugin.utils.bloom import enable_bloom_effect_if_needed
 from sbstudio.plugin.utils.pyro_markers import update_pyro_particles_of_object
 
@@ -81,6 +82,21 @@ def regenerate_storyboard_entries_or_transitions(*args):
         scene.skybrush.storyboard._regenerate_entries_or_transitions()
 
 
+def setup_takeoff_pods(*args):
+    """Creates the "Takeoff pods" collection and generates predefined pods.
+
+    Note that we need to create this collection earlier than the others
+    that are only created in prepare.py, as the Takeoff pods collection
+    is needed in advance, before takeoff grid creation, so that users
+    can add their own pods or select from predefined ones.
+    """
+    takeoff_pods = Collections.find_takeoff_pods(create=True)
+    scene = bpy.context.scene
+    if takeoff_pods and scene:
+        link_object_to_scene(takeoff_pods, scene=scene, allow_nested=True)
+        TakeoffPods.create_takeoff_pods()
+
+
 def _config_logging(*args):
     import logging
 
@@ -109,6 +125,7 @@ class InitializationTask(Task):
             setup_random_seed,
             update_pyro_particles_of_drones,
             regenerate_storyboard_entries_or_transitions,
+            setup_takeoff_pods,
             # enable this below for neat logs
             # _config_logging,
             perform_migrations,

--- a/typings/bpy/types.pyi
+++ b/typings/bpy/types.pyi
@@ -354,7 +354,9 @@ class Mesh(ID):
     edges: bpy_prop_collection[MeshEdge]
     polygons: bpy_prop_collection[MeshPolygon]
 
+    def from_pydata(self, vertices, edges, faces, shade_flat=True) -> None: ...
     def transform(self, matrix: Matrix, shape_keys: bool = False) -> None: ...
+    def update(self) -> None: ...
 
 class NodeTree(ID):
     nodes: bpy_prop_collection[Node]


### PR DESCRIPTION
This PR is an alternative solution for supporting predefined takeoff pods, inspired by the PR of @UavShow in https://github.com/skybrush-io/studio-blender/pull/67/

There is a "Takeoff pods" collection now that will contain predefined templates and on advanced takeoff config one can select a pod to multiply all grid positions with the pods. 

## TODO
- [x] "Takeoff pods" collection is not yet initialized upon startup, nor is the migration from old files implemented
- [ ] we need more templates from more manufacturers, now only DroneMax is added as a first example
- [ ] documentation
- [ ] changelog