### PR TITLE
fix: light-effect image sampling and randomness on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Drone groups can now be rearranged in the "Drone Groups" panel of the Skybrush tab.
 
+### Fixed
+
+- Fix image-based light effects for portrait (and other non-square) images that were
+  accidentally broken after the migration to NumPy, thanks to
+  [@VGYO](https://github.com/VGYO). Also restored shared X/Y randomness offsets (same
+  per-drone offset for both axes, matching pre-vectorization / 4.4.x behaviour). See
+  [#76](https://github.com/skybrush-io/studio-blender/pull/76) for more details.
+
+- Fix an `OverflowError` on Windows when generating random number sequences due to the
+  native NumPy `int_` type being 32-bit on that platform. Many thanks to
+  [@VGYO](https://github.com/VGYO). See
+  [#76](https://github.com/skybrush-io/studio-blender/pull/76) for more details.
+
 ## [5.0.0] - 2026-07-23
 
 ### Breaking change

--- a/src/modules/sbstudio/math/rng.py
+++ b/src/modules/sbstudio/math/rng.py
@@ -5,7 +5,7 @@ from random import Random
 from threading import Lock
 from typing import Self, overload
 
-from numpy import array, concatenate, float32, int_
+from numpy import array, concatenate, float32, int64
 from numpy.typing import NDArray
 
 _GROWTH_BLOCK_SIZE = 4096
@@ -17,8 +17,13 @@ class RandomSequence(Sequence[int]):
     can be accessed by indexing.
     """
 
-    _cache: NDArray[int_]
-    """Cached items of the sequence that were already generated."""
+    _cache: NDArray[int64]
+    """Cached items of the sequence that were already generated.
+
+    Stored as ``int64`` rather than the platform ``int_`` / ``int32`` because
+    sequence values may be as large as ``0xFFFFFFFF``, which overflows signed
+    32-bit integers (notably on Windows).
+    """
 
     _max: int
     """Maximum value that can be returned in the sequence."""
@@ -52,7 +57,7 @@ class RandomSequence(Sequence[int]):
                 and that returns an instance of Random_ to use. ``None`` must
                 be interpreted by the function as "use a random seed".
         """
-        self._cache = array([], dtype=int_)
+        self._cache = array([], dtype=int64)
         self._rng_factory = rng_factory
         self._rng = rng_factory(seed)
         self._max = max
@@ -97,7 +102,7 @@ class RandomSequence(Sequence[int]):
                 extra = target - current
                 new_values = array(
                     [self._rng.randint(0, self._max) for _ in range(extra)],
-                    dtype=int_,
+                    dtype=int64,
                 )
                 self._cache = concatenate([self._cache, new_values])
 
@@ -119,7 +124,7 @@ class RandomSequence(Sequence[int]):
         """Returns the random number at the given index in the sequence."""
         return self[index]
 
-    def get_array(self, start: int, length: int) -> NDArray[int_]:
+    def get_array(self, start: int, length: int) -> NDArray[int64]:
         """Returns a NumPy array of the given length containing the random
         numbers from ``start`` onward in the sequence.
 
@@ -128,7 +133,7 @@ class RandomSequence(Sequence[int]):
             length: the number of elements to return
 
         Returns:
-            a NumPy array of shape ``(length,)`` with dtype int
+            a NumPy array of shape ``(length,)`` with dtype int64
         """
         stop = start + length
         if stop > len(self._cache):
@@ -148,10 +153,14 @@ class RandomSequence(Sequence[int]):
             length: the number of elements to return
 
         Returns:
-            a NumPy array of shape ``(length,)`` with dtype float64
+            a NumPy array of shape ``(length,)`` with dtype float32
         """
         if self.max > 0:
-            return self.get_array(start, length).astype(float32) / self.max
+            # Divide in float64 first so values near 0xFFFFFFFF do not lose
+            # precision (or overflow) when cast to float32 before division.
+            return (self.get_array(start, length).astype("float64") / self.max).astype(
+                float32
+            )
         else:
             return self.get_array(start, length).astype(float32) * 0 + 0.5
 

--- a/src/modules/sbstudio/plugin/model/light_effects.py
+++ b/src/modules/sbstudio/plugin/model/light_effects.py
@@ -981,17 +981,17 @@ class LightEffect(PropertyGroup):
         # TODO(ntamas): if possible, calculate only for the non-masked drones
         if self.randomness != 0:
             random_seq = context.random_seq
+            # Use the same per-drone random offset for X and Y, matching the
+            # pre-vectorization behaviour (and 4.4.x). Independent ranges for the
+            # two axes made image-based effects look overly scrambled.
+            offsets = (
+                random_seq.get_array_01(0, num_drones) - 0.5
+            ) * self.randomness
             if needs_output_x:
-                offsets = (
-                    random_seq.get_array_01(0, num_drones) - 0.5
-                ) * self.randomness
                 outputs_x += offsets
                 outputs_x %= 1.0
                 constant_output_x = None
             if needs_output_y:
-                offsets = (
-                    random_seq.get_array_01(num_drones, num_drones) - 0.5
-                ) * self.randomness
                 outputs_y += offsets
                 outputs_y %= 1.0
                 constant_output_y = None
@@ -1022,23 +1022,31 @@ class LightEffect(PropertyGroup):
             # Image based 2D light effect
             assert needs_output_x and needs_output_y
 
-            width, height = color_image.size
             pixels_with_colorspace = self.get_image_pixels()
 
             if pixels_with_colorspace is None:
                 colors.fill(0.0)
             else:
-                xs = (width * outputs_x[active_drones]).astype(int)
-                ys = (height * outputs_y[active_drones]).astype(int)
-                xs = where(xs < width, xs, width - 1)
-                ys = where(ys < height, ys, height - 1)
+                # Prefer the cached pixel array shape over color_image.size so
+                # portrait/landscape orientation cannot go out of bounds when
+                # the reshape order was wrong or the image size changed.
+                height, width = pixels_with_colorspace.pixels.shape[:2]
+                if width <= 0 or height <= 0:
+                    colors.fill(0.0)
+                else:
+                    xs = (width * outputs_x[active_drones]).astype(int)
+                    ys = (height * outputs_y[active_drones]).astype(int)
+                    xs = xs.clip(0, width - 1)
+                    ys = ys.clip(0, height - 1)
 
-                chosen_pixels: NDArray[float32] = pixels_with_colorspace.pixels[ys, xs]
-                convert_pixels_to_linear_in_place(
-                    chosen_pixels, pixels_with_colorspace.colorspace
-                )
+                    chosen_pixels: NDArray[float32] = pixels_with_colorspace.pixels[
+                        ys, xs
+                    ]
+                    convert_pixels_to_linear_in_place(
+                        chosen_pixels, pixels_with_colorspace.colorspace
+                    )
 
-                colors[active_drones, :] = chosen_pixels
+                    colors[active_drones, :] = chosen_pixels
 
         elif color_function is not None:
             # Custom function based light effect

--- a/src/modules/sbstudio/plugin/utils/image.py
+++ b/src/modules/sbstudio/plugin/utils/image.py
@@ -146,7 +146,7 @@ class PixelsWithColorspace:
         # image.size is (width, height); Blender stores pixels row-major with
         # stride=width, so the array must be shaped (height, width, channels).
         width, height = image.size
-        pixels = pixels.reshape((height, width, -1))
+        pixels = pixels.reshape((height, width, 4))
 
         colorspace_settings = image.colorspace_settings
         colorspace = colorspace_settings.name if not colorspace_settings.is_data else ""

--- a/src/modules/sbstudio/plugin/utils/image.py
+++ b/src/modules/sbstudio/plugin/utils/image.py
@@ -143,7 +143,10 @@ class PixelsWithColorspace:
         pixel_data = image.pixels
         pixels: NDArray[float32] = empty(len(pixel_data), dtype=float32)
         pixel_data.foreach_get(pixels)
-        pixels = pixels.reshape(tuple(image.size) + (-1,))
+        # image.size is (width, height); Blender stores pixels row-major with
+        # stride=width, so the array must be shaped (height, width, channels).
+        width, height = image.size
+        pixels = pixels.reshape((height, width, -1))
 
         colorspace_settings = image.colorspace_settings
         colorspace = colorspace_settings.name if not colorspace_settings.is_data else ""

--- a/test/test_rng_random_sequence.py
+++ b/test/test_rng_random_sequence.py
@@ -129,7 +129,7 @@ class TestGetArray:
         arr = seq.get_array(0, 5)
         assert isinstance(arr, np.ndarray)
         assert arr.shape == (5,)
-        assert arr.dtype == np.intp
+        assert arr.dtype == np.int64
         assert list(arr) == [seq[i] for i in range(5)]
 
     def test_get_array_with_offset(self):
@@ -191,8 +191,20 @@ class TestGetArray01:
     def test_get_array_01_matches_get_array_divided(self):
         seq = RandomSequence(seed=42, max=1000)
         arr = seq.get_array_01(3, 7)
-        expected = seq.get_array(3, 7).astype(np.float32) / seq.max
+        expected = (seq.get_array(3, 7).astype(np.float64) / seq.max).astype(np.float32)
         assert arr == pytest.approx(expected)
+
+    def test_get_array_default_max_does_not_overflow(self):
+        # On Windows, storing 0..0xFFFFFFFF in a 32-bit signed dtype raises
+        # OverflowError; int64 storage must accept the default max.
+        seq = RandomSequence(seed=42)
+        arr = seq.get_array(0, 64)
+        assert arr.dtype == np.int64
+        assert (arr >= 0).all()
+        assert (arr <= 0xFFFFFFFF).all()
+        arr01 = seq.get_array_01(0, 64)
+        assert (arr01 >= 0).all()
+        assert (arr01 <= 1).all()
 
     def test_get_array_01_zero_max(self):
         seq = RandomSequence(seed=42, max=0)


### PR DESCRIPTION
## Summary
- Fix image-based light effects for portrait (and other non-square) images by reshaping Blender pixel buffers as `(height, width, channels)` instead of `(width, height, ...)`, and clamp sample coordinates to the cached pixel array bounds.
- Restore shared X/Y randomness offsets (same per-drone offset for both axes, matching pre-vectorization / 4.4.x behaviour).
- Store `RandomSequence` cache values as `int64` and divide in float64 before casting to float32, so the default max `0xFFFFFFFF` no longer raises `OverflowError` on Windows when Randomness > 0.

## Test plan
- [ ] Open a show with a portrait video/image light effect and scrub the timeline — no `IndexError`; mapping looks correctly oriented
- [ ] Enable Randomness on an image-based light effect on Windows — effect updates without console `OverflowError` / failed frame handler
- [ ] Compare Randomness look vs 4.4.x for the same seed/show — X/Y should share offsets (not independently scrambled)
- [ ] `pytest test/test_rng_random_sequence.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved random-number generation consistency across platforms.
  * Prevented overflow errors on Windows and preserved precision in floating-point arrays.
  * Improved image sampling for non-square images with safer coordinate handling.
  * Correctly handles images with empty dimensions.
  * Corrected pixel data reshaping for images with varying dimensions.
  * Restored consistent random offsets across image axes.

* **Tests**
  * Added coverage for overflow prevention, valid normalized ranges, and consistent integer output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->