### PR TITLE
fix: re-link Drones into the view layer during prepare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and the target Blender FPS were not divisors of each other. 
   Many thanks to @MartinM for the bug report.
 
+- Linking the main permanent collections (Drones, Drone Groups etc.) to the scene
+  got fixed (no crash now on creating takeoff grids on non-empty template files),
+  and the Drone Groups collection is now ensured to be a child of the root collection
+  of the scene. Many thanks to [@VGYO](https://github.com/VGYO). See
+  [#77](https://github.com/skybrush-io/studio-blender/pull/77) for more details.
+
 ## [5.0.1] - 2026-08-05
 
 ### Added

--- a/src/modules/sbstudio/plugin/constants.py
+++ b/src/modules/sbstudio/plugin/constants.py
@@ -211,12 +211,14 @@ class Collections:
 
     @classmethod
     def _on_drone_group_collection_created(cls, coll: Collection) -> None:
-        # Note that once the Drone Groups collection is created, we need to link
-        # it to the scene. However, if we do it here, somehow, strangly, it gets
-        # inside the actual/first collection not in the root of the scene; to
-        # workaround that peculiar behavior, we must have a direct call to
-        # `link_to_scene()` after the `Collections.find_drone_groups(create=True)`
-        # call has returned the new collection.
+        # We deliberately do NOT link the new collection to the scene here. The
+        # collection was just created via `bpy.data.collections.new()`, so it has
+        # no parent yet; linking such an unparented datablock into the scene's
+        # hierarchy from within this callback makes Blender place it under the
+        # currently active (first) top-level collection instead of the scene
+        # root, since its parent is not yet resolved in the same evaluation
+        # frame. `link_to_scene()` is therefore called on the caller side, only
+        # after `find_drone_groups(create=True)` has returned.
         bpy.context.scene.skybrush.settings.drone_group_collection = coll
 
 

--- a/src/modules/sbstudio/plugin/constants.py
+++ b/src/modules/sbstudio/plugin/constants.py
@@ -15,7 +15,6 @@ from bpy.types import Collection
 
 from .materials import create_colored_material, create_glowing_material
 from .meshes import create_cone, create_icosphere
-from .objects import link_to_scene
 from .utils import (
     ensure_object_exists_in_collection,
     get_object_in_collection,
@@ -213,7 +212,6 @@ class Collections:
     @classmethod
     def _on_drone_group_collection_created(cls, coll: Collection) -> None:
         bpy.context.scene.skybrush.settings.drone_group_collection = coll
-        link_to_scene(coll)
 
 
 class Formations:

--- a/src/modules/sbstudio/plugin/constants.py
+++ b/src/modules/sbstudio/plugin/constants.py
@@ -211,6 +211,12 @@ class Collections:
 
     @classmethod
     def _on_drone_group_collection_created(cls, coll: Collection) -> None:
+        # Note that once the Drone Groups collection is created, we need to link
+        # it to the scene. However, if we do it here, somehow, strangly, it gets
+        # inside the actual/first collection not in the root of the scene; to
+        # workaround that peculiar behavior, we must have a direct call to
+        # `link_to_scene()` after the `Collections.find_drone_groups(create=True)`
+        # call has returned the new collection.
         bpy.context.scene.skybrush.settings.drone_group_collection = coll
 
 

--- a/src/modules/sbstudio/plugin/model/drone_groups.py
+++ b/src/modules/sbstudio/plugin/model/drone_groups.py
@@ -59,19 +59,14 @@ class DroneGroupsProperties(PropertyGroup):
         self, name: str = "New Drone Group", *, select: bool = False
     ) -> Collection:
         """Creates a new drone group and adds it to the list of drone groups."""
-        drone_groups = Collections.find_drone_groups(create=True)
-        # Note that the call below might cause performance issues as
-        # searching for a collection hierarchically is O(n); if that
-        # is the case, we need to infer from the call above whether
-        # we have just created the drone groups collection and link
-        # only in that case; also, we must link the collection here on the
-        # caller side and NOT inside the `_on_drone_group_collection_created()`
-        # callback: the collection is brand new and has no parent yet, so
-        # linking it from within the callback makes Blender place it under the
-        # currently active (first) top-level collection instead of the scene
-        # root, because its parent is not yet resolved in the same evaluation
-        # frame.
-        link_to_scene(drone_groups, allow_nested=True)
+        # Note that we have the double call below to make sure `link_to_scene()` is
+        # only called if the Drone Groups collection is just created, as it performs
+        # an O(n) search in the scenes collection tree.
+        drone_groups = Collections.find_drone_groups(create=False)
+        if drone_groups is None:
+            drone_groups = Collections.find_drone_groups(create=True)
+            link_to_scene(drone_groups, allow_nested=True)
+        assert drone_groups is not None
 
         new_group = bpy.data.collections.new(name)
         drone_groups.children.link(new_group)

--- a/src/modules/sbstudio/plugin/model/drone_groups.py
+++ b/src/modules/sbstudio/plugin/model/drone_groups.py
@@ -10,6 +10,7 @@ from bpy.props import IntProperty
 from bpy.types import Collection, Context, Object, PropertyGroup
 
 from sbstudio.plugin.constants import Collections
+from sbstudio.plugin.objects import link_to_scene
 from sbstudio.plugin.utils import with_context
 
 __all__ = ("DroneGroupsProperties", "get_drone_groups")
@@ -59,6 +60,15 @@ class DroneGroupsProperties(PropertyGroup):
     ) -> Collection:
         """Creates a new drone group and adds it to the list of drone groups."""
         drone_groups = Collections.find_drone_groups(create=True)
+        # Note that the call below might cause performance issues as
+        # searching for a collection hierarchically is O(n); if that
+        # is the case, we need to infer from the call above whether
+        # we have just created the drone groups collection and link
+        # only in that case; also note that if we put the `link_to_scene()`
+        # call inside the `_on_drone_group_collection_created()` callback
+        # of the call above, somehow strangly the collection does not get
+        # linked to the root of the scene but to the first collection
+        link_to_scene(drone_groups, allow_nested=True)
 
         new_group = bpy.data.collections.new(name)
         drone_groups.children.link(new_group)

--- a/src/modules/sbstudio/plugin/model/drone_groups.py
+++ b/src/modules/sbstudio/plugin/model/drone_groups.py
@@ -64,10 +64,13 @@ class DroneGroupsProperties(PropertyGroup):
         # searching for a collection hierarchically is O(n); if that
         # is the case, we need to infer from the call above whether
         # we have just created the drone groups collection and link
-        # only in that case; also note that if we put the `link_to_scene()`
-        # call inside the `_on_drone_group_collection_created()` callback
-        # of the call above, somehow strangly the collection does not get
-        # linked to the root of the scene but to the first collection
+        # only in that case; also, we must link the collection here on the
+        # caller side and NOT inside the `_on_drone_group_collection_created()`
+        # callback: the collection is brand new and has no parent yet, so
+        # linking it from within the callback makes Blender place it under the
+        # currently active (first) top-level collection instead of the scene
+        # root, because its parent is not yet resolved in the same evaluation
+        # frame.
         link_to_scene(drone_groups, allow_nested=True)
 
         new_group = bpy.data.collections.new(name)

--- a/src/modules/sbstudio/plugin/objects.py
+++ b/src/modules/sbstudio/plugin/objects.py
@@ -109,19 +109,6 @@ def get_vertices_of_object_in_vertex_group_by_name(
     return get_vertices_of_object_in_vertex_group(object, group) if group else []
 
 
-def _is_in_scene_collection_tree(collection: Collection, scene: Scene) -> bool:
-    """Returns whether ``collection`` appears anywhere under the scene's
-    master collection (including nested children).
-    """
-
-    def walk(coll: Collection) -> bool:
-        if coll == collection:
-            return True
-        return any(walk(child) for child in coll.children)
-
-    return walk(scene.collection)
-
-
 @with_scene
 def link_to_scene(
     object: Object | Collection,
@@ -142,23 +129,19 @@ def link_to_scene(
     """
     assert scene is not None
 
+    if object is scene.collection:
+        return
+
     parent = scene.collection
     is_collection = isinstance(object, Collection)
     parent = parent.children if is_collection else parent.objects
 
     if allow_nested:
-        # Prefer an explicit collection-tree walk over scene.user_of_id().
-        # PointerProperties such as settings.drone_collection inflate
-        # user_of_id even when the collection is not in the scene hierarchy,
-        # which previously prevented re-linking and made newly created drones
-        # unselectable ("not in View Layer").
+        # we need to check the entire scene collection tree for the object reference
         if is_collection:
-            should_link = not _is_in_scene_collection_tree(object, scene)
+            should_link = object not in scene.collection.children_recursive
         else:
-            should_link = not any(
-                _is_in_scene_collection_tree(coll, scene)
-                for coll in object.users_collection
-            )
+            should_link = object not in scene.collection.all_objects
     else:
         # We need to check whether the scene references the object directly
         should_link = object not in parent.values()

--- a/src/modules/sbstudio/plugin/objects.py
+++ b/src/modules/sbstudio/plugin/objects.py
@@ -12,6 +12,7 @@ from .utils import with_context, with_scene
 __all__ = (
     "create_object",
     "duplicate_object",
+    "ensure_direct_scene_child",
     "get_axis_aligned_bounding_box_of_object",
     "get_derived_object_after_applying_modifiers",
     "get_vertices_of_object",
@@ -19,6 +20,7 @@ __all__ = (
     "get_vertices_of_object_in_vertex_group_by_name",
     "link_to_scene",
     "object_contains_vertex",
+    "order_child_collections",
     "remove_objects",
 )
 
@@ -109,6 +111,71 @@ def get_vertices_of_object_in_vertex_group_by_name(
     return get_vertices_of_object_in_vertex_group(object, group) if group else []
 
 
+def _is_in_scene_collection_tree(collection: Collection, scene: Scene) -> bool:
+    """Returns whether ``collection`` appears anywhere under the scene's
+    master collection (including nested children).
+    """
+
+    def walk(coll: Collection) -> bool:
+        if coll == collection:
+            return True
+        return any(walk(child) for child in coll.children)
+
+    return walk(scene.collection)
+
+
+def ensure_direct_scene_child(
+    collection: Collection, *, scene: Scene | None = None
+) -> None:
+    """Ensure ``collection`` is a direct child of the scene master collection.
+
+    Unlinks it from any nested parents first. Unlike ``link_to_scene(...,
+    allow_nested=True)``, this actively promotes nested collections to the
+    scene root.
+    """
+    if scene is None:
+        scene = bpy.context.scene
+    assert scene is not None
+
+    root = scene.collection
+
+    for parent in list(bpy.data.collections):
+        if collection in parent.children.values():
+            parent.children.unlink(collection)
+
+    for other_scene in bpy.data.scenes:
+        if collection in other_scene.collection.children.values():
+            other_scene.collection.children.unlink(collection)
+
+    root.children.link(collection)
+
+
+def order_child_collections(
+    parent: Collection, ordered: Iterable[Collection]
+) -> None:
+    """Reorder ``parent``'s child collections so ``ordered`` appear in that
+    relative sequence.
+
+    Other children keep their relative order. The block of ordered collections
+    is placed starting at the earliest current index among them.
+    """
+    children = parent.children
+    current = list(children)
+    present = [coll for coll in ordered if coll in children.values()]
+    if len(present) < 2:
+        return
+
+    insert_at = min(current.index(coll) for coll in present)
+    remaining = [coll for coll in current if coll not in present]
+    insert_at = min(insert_at, len(remaining))
+    desired = remaining[:insert_at] + present + remaining[insert_at:]
+
+    for target_index, coll in enumerate(desired):
+        current_index = list(children).index(coll)
+        if current_index != target_index:
+            children.move(current_index, target_index)
+
+
 @with_scene
 def link_to_scene(
     object: Object | Collection,
@@ -134,13 +201,18 @@ def link_to_scene(
     parent = parent.children if is_collection else parent.objects
 
     if allow_nested:
-        # Nested membership is allowed so we simply check whether the scene
-        # already uses the object indirectly
-        num_refs = scene.user_of_id(object)
-        if object is scene.skybrush.settings.drone_collection:
-            # This reference does not count
-            num_refs -= 1
-        should_link = num_refs < 1
+        # Prefer an explicit collection-tree walk over scene.user_of_id().
+        # PointerProperties such as settings.drone_collection inflate
+        # user_of_id even when the collection is not in the scene hierarchy,
+        # which previously prevented re-linking and made newly created drones
+        # unselectable ("not in View Layer").
+        if is_collection:
+            should_link = not _is_in_scene_collection_tree(object, scene)
+        else:
+            should_link = not any(
+                _is_in_scene_collection_tree(coll, scene)
+                for coll in object.users_collection
+            )
     else:
         # We need to check whether the scene references the object directly
         should_link = object not in parent.values()

--- a/src/modules/sbstudio/plugin/objects.py
+++ b/src/modules/sbstudio/plugin/objects.py
@@ -132,9 +132,9 @@ def link_to_scene(
     if object is scene.collection:
         return
 
-    parent = scene.collection
+    root = scene.collection
     is_collection = isinstance(object, Collection)
-    parent = parent.children if is_collection else parent.objects
+    parent = root.children if is_collection else root.objects
 
     if allow_nested:
         # we need to check the entire scene collection tree for the object reference

--- a/src/modules/sbstudio/plugin/objects.py
+++ b/src/modules/sbstudio/plugin/objects.py
@@ -12,7 +12,6 @@ from .utils import with_context, with_scene
 __all__ = (
     "create_object",
     "duplicate_object",
-    "ensure_direct_scene_child",
     "get_axis_aligned_bounding_box_of_object",
     "get_derived_object_after_applying_modifiers",
     "get_vertices_of_object",
@@ -20,7 +19,6 @@ __all__ = (
     "get_vertices_of_object_in_vertex_group_by_name",
     "link_to_scene",
     "object_contains_vertex",
-    "order_child_collections",
     "remove_objects",
 )
 
@@ -122,58 +120,6 @@ def _is_in_scene_collection_tree(collection: Collection, scene: Scene) -> bool:
         return any(walk(child) for child in coll.children)
 
     return walk(scene.collection)
-
-
-def ensure_direct_scene_child(
-    collection: Collection, *, scene: Scene | None = None
-) -> None:
-    """Ensure ``collection`` is a direct child of the scene master collection.
-
-    Unlinks it from any nested parents first. Unlike ``link_to_scene(...,
-    allow_nested=True)``, this actively promotes nested collections to the
-    scene root.
-    """
-    if scene is None:
-        scene = bpy.context.scene
-    assert scene is not None
-
-    root = scene.collection
-
-    for parent in list(bpy.data.collections):
-        if collection in parent.children.values():
-            parent.children.unlink(collection)
-
-    for other_scene in bpy.data.scenes:
-        if collection in other_scene.collection.children.values():
-            other_scene.collection.children.unlink(collection)
-
-    root.children.link(collection)
-
-
-def order_child_collections(
-    parent: Collection, ordered: Iterable[Collection]
-) -> None:
-    """Reorder ``parent``'s child collections so ``ordered`` appear in that
-    relative sequence.
-
-    Other children keep their relative order. The block of ordered collections
-    is placed starting at the earliest current index among them.
-    """
-    children = parent.children
-    current = list(children)
-    present = [coll for coll in ordered if coll in children.values()]
-    if len(present) < 2:
-        return
-
-    insert_at = min(current.index(coll) for coll in present)
-    remaining = [coll for coll in current if coll not in present]
-    insert_at = min(insert_at, len(remaining))
-    desired = remaining[:insert_at] + present + remaining[insert_at:]
-
-    for target_index, coll in enumerate(desired):
-        current_index = list(children).index(coll)
-        if current_index != target_index:
-            children.move(current_index, target_index)
 
 
 @with_scene

--- a/src/modules/sbstudio/plugin/operators/prepare.py
+++ b/src/modules/sbstudio/plugin/operators/prepare.py
@@ -1,11 +1,7 @@
 from bpy.types import Operator
 
 from sbstudio.plugin.constants import Collections
-from sbstudio.plugin.objects import (
-    ensure_direct_scene_child,
-    link_to_scene,
-    order_child_collections,
-)
+from sbstudio.plugin.objects import link_to_scene
 from sbstudio.plugin.state import get_file_specific_state
 
 __all__ = ("PrepareSceneOperator",)
@@ -33,16 +29,9 @@ class PrepareSceneOperator(Operator):
         templates = Collections.find_templates()
 
         link_to_scene(drones, allow_nested=True)
+        link_to_scene(drone_groups, allow_nested=True)
         link_to_scene(formations, allow_nested=True)
         link_to_scene(templates, allow_nested=True)
-        # Keep Drone Groups as the last scene-root sibling. Assigning drones into
-        # group sub-collections makes the Outliner very tall; if Drone Groups
-        # sits above Drones/Formations, those collections get pushed far down.
-        ensure_direct_scene_child(drone_groups, scene=context.scene)
-        order_child_collections(
-            context.scene.collection,
-            [drones, formations, templates, drone_groups],
-        )
 
         # Note that we do not create the drone template here yet as
         # its size might depend on later takeoff grid parameters

--- a/src/modules/sbstudio/plugin/operators/prepare.py
+++ b/src/modules/sbstudio/plugin/operators/prepare.py
@@ -1,7 +1,11 @@
 from bpy.types import Operator
 
 from sbstudio.plugin.constants import Collections
-from sbstudio.plugin.objects import link_to_scene
+from sbstudio.plugin.objects import (
+    ensure_direct_scene_child,
+    link_to_scene,
+    order_child_collections,
+)
 from sbstudio.plugin.state import get_file_specific_state
 
 __all__ = ("PrepareSceneOperator",)
@@ -29,9 +33,16 @@ class PrepareSceneOperator(Operator):
         templates = Collections.find_templates()
 
         link_to_scene(drones, allow_nested=True)
-        link_to_scene(drone_groups, allow_nested=True)
         link_to_scene(formations, allow_nested=True)
         link_to_scene(templates, allow_nested=True)
+        # Keep Drone Groups as the last scene-root sibling. Assigning drones into
+        # group sub-collections makes the Outliner very tall; if Drone Groups
+        # sits above Drones/Formations, those collections get pushed far down.
+        ensure_direct_scene_child(drone_groups, scene=context.scene)
+        order_child_collections(
+            context.scene.collection,
+            [drones, formations, templates, drone_groups],
+        )
 
         # Note that we do not create the drone template here yet as
         # its size might depend on later takeoff grid parameters

--- a/typings/bpy/types.pyi
+++ b/typings/bpy/types.pyi
@@ -341,7 +341,7 @@ class Action(ID):
 class Collection(ID):
     all_objects: bpy_prop_collection[Object]
     children: CollectionChildren
-    children_recursive: bpy_prop_collection[Collection]
+    children_recursive: list[Collection]
     objects: CollectionObjects
 
 class ColorManagedInputColorspaceSettings(ID):

--- a/typings/bpy/types.pyi
+++ b/typings/bpy/types.pyi
@@ -339,7 +339,9 @@ class Action(ID):
     ) -> FCurve: ...
 
 class Collection(ID):
+    all_objects: bpy_prop_collection[Object]
     children: CollectionChildren
+    children_recursive: bpy_prop_collection[Collection]
     objects: CollectionObjects
 
 class ColorManagedInputColorspaceSettings(ID):


### PR DESCRIPTION
## Summary
- Fix `link_to_scene(..., allow_nested=True)` to detect scene membership by walking the collection tree instead of trusting `scene.user_of_id()`.
- Ensured that the "Drone groups" collection appear as a root level collection of the scene.

## Test plan
- [ ] Reproduce an unlinked `Drones` collection, then Create Takeoff Grid / prepare — collection is re-linked and drones are selectable
- [ ] Confirm prepare still links Drones, Drone Groups, Formations, and Templates without changing Outliner sibling order

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved scene linking for collections nested within other collections.
* Ensured objects are recognized correctly across their full collection hierarchy.
* Corrected master collection handling for more consistent scene organization.
* Ensured newly created drone-group collections are linked to scenes when appropriate.
* Reduced unexpected collection or object visibility caused by inconsistent linking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->