### PR TITLE
fix: sample keyed object.color during skyc/CSV export

### DIFF
--- a/src/modules/sbstudio/plugin/tasks/light_effects/session.py
+++ b/src/modules/sbstudio/plugin/tasks/light_effects/session.py
@@ -118,22 +118,18 @@ class LightEffectUpdateSession:
         assert self._scene is not None
         assert self._frame is not None
 
+        had_effects = self._context is not None
         state = self._context
-        if state is None and self._owner._has_base_colors():
-            # No color updates were applied in this session but the user has just turned
-            # off the last color effect so pretend that there were some effects
+        if state is None:
+            # No light effects were applied this frame. Snapshot evaluated
+            # object.color (including F-curves) so skyc / CSV export can sample
+            # colors keyed directly on the drone.
             state = self._ensure_context()
-            clear_base_color_cache_at_end = True
-        else:
-            clear_base_color_cache_at_end = False
 
         if state is None:
-            # No color updates were applied and it has been like this even in the
-            # previous frame so no need to calculate the final colors
             return LightEffectUpdate.NOP
 
         self._final_colors = state.backdrop
-        if clear_base_color_cache_at_end:
-            self._owner._clear_base_colors()
-
-        return LightEffectUpdate(state.drones, state.positions, state.backdrop, True)
+        return LightEffectUpdate(
+            state.drones, state.positions, state.backdrop, had_effects
+        )

--- a/src/modules/sbstudio/plugin/tasks/light_effects/updater.py
+++ b/src/modules/sbstudio/plugin/tasks/light_effects/updater.py
@@ -3,18 +3,13 @@ from numpy import empty, float32
 from numpy.typing import NDArray
 
 from sbstudio.model.types import RGBAColor
-from sbstudio.plugin.colors import get_colors_of_drones_fast
+from sbstudio.plugin.colors import get_color_of_drone, get_colors_of_drones_fast
 from sbstudio.plugin.model.light_effects import LightEffectUpdate
 from sbstudio.utils import measure_time
 
 from .session import LightEffectUpdateSession
 
 __all__ = ("LightEffectUpdater",)
-
-WHITE: RGBAColor = (1, 1, 1, 1)
-"""White color, used as a base color when no info is available for a newly added
-drone.
-"""
 
 
 class LightEffectUpdater:
@@ -60,19 +55,29 @@ class LightEffectUpdater:
 
         The returned value is a copy of the color in the cache. It can be modified, but
         the modifications will not affect the cached value.
+
+        Falls back to the evaluated ``object.color`` when the cache has no entry
+        for this drone.
         """
         idx = self._drone_to_row_index.get(drone)
         if idx is not None:
             return tuple(self._base_colors[idx])
-        return WHITE
+        # No light-effect cache (effects disabled, or none active this frame).
+        # Fall back to evaluated object.color so keyed LED colors still export.
+        return get_color_of_drone(drone)
 
     def get_final_color_of_drone(self, drone: Object) -> RGBAColor:
         """Returns the (cached) final color of the drone at the current frame
         after all active light effects are applied on it.
+
+        When no light-effect cache exists for this drone (for example because
+        light effects are disabled, or none are active on the current frame),
+        falls back to the evaluated ``object.color`` so colors keyed directly
+        on the drone are still sampled during skyc / CSV export.
         """
         idx = self._drone_to_row_index.get(drone)
         if idx is None:
-            return WHITE
+            return get_color_of_drone(drone)
 
         final_colors = self._session._final_colors
         return (


### PR DESCRIPTION
## Problem

Colors keyed directly on `object.color` (the same property Studio uses for LED color, including `create_keyframe_for_color_of_drone()`) are **visible in the viewport** but **not written into exported `.skyc` / CSV light programs**.

### Why

5.x export samples `get_final_color_of_drone()`, which reads the light-effect updater cache — not `object.color`.

That cache is only filled when at least one light effect is applied on the current frame. In these common cases the cache is empty:

- Light effects are disabled
- Light effects are enabled, but none are active on that frame
- The user colors drones only by keyframing `object.color` (no light effects)

`get_final_color_of_drone()` then returned white `(1, 1, 1, 1)`. Export therefore collapsed the light program to constant white (or omitted the keyed color changes). 4.4.x sampled `object.color` directly, so this workflow used to work.

Export also suspends the callbacks that write computed colors back to `object.color`, so the cache **must** be correct; falling back to evaluated `object.color` restores the 4.4.x behaviour when no effect overlay exists.

## Fix

- If the light-effect cache has no row for a drone, `get_final_color_of_drone()` / `get_base_color_of_drone()` fall back to evaluated `object.color` (F-curves included).
- When a frame has no active light effects, still snapshot `object.color` into the cache so export can sample it. `has_active_effects` stays false so the material callback does not overwrite keyed colors.

Light effects still overlay on top of `object.color` when they are active.

## Test plan

- [ ] Keyframe `object.color` on drones (no light effects, or effects disabled). Export skyc and CSV — light program follows the keyed colors, not constant white
- [ ] Same show with a light effect active — effect colors still export; keyed `object.color` is the backdrop
- [ ] Frame with no active effect in a show that has effects on other frames — keyed / base colors export on the inactive frames
- [ ] Viewport playback still matches previous light-effect behaviour

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved evaluated drone colors, including animated F-curve colors, when no light effects are applied.
  * Improved color reporting by using the evaluated drone color instead of defaulting to white when cached effect colors are unavailable.
  * Light-effect updates now accurately indicate whether effects were applied during the session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->