### PR TITLE
Python 3.14 lazy annotations support

### DIFF
--- a/src/modules/sbstudio/plugin/plugin_helpers.py
+++ b/src/modules/sbstudio/plugin/plugin_helpers.py
@@ -53,9 +53,8 @@ def _make_annotations(cls):
     )
 
     if bl_props:
-        if "__annotations__" not in cls.__dict__:
-            cls.__annotations__ = {}
-        annotations = cls.__dict__["__annotations__"]
+        annotations = getattr(cls, "__annotations__", {})
+        cls.__annotations__ = annotations
         for k, v in bl_props.items():
             annotations[k] = v
             delattr(cls, k)


### PR DESCRIPTION
Since Python 3.14, `__annotations__` is a descriptor, it's no longer in `__dict__` (regardless of whether it is ever assigned a value).

See [PEP 649](https://peps.python.org/pep-0649/) and [PEP 749](https://peps.python.org/pep-0749/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal annotation initialization without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->