### PR TITLE
fix: do not cache Collection.objects across light-effect updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [main]
+
+### Fixed
+
+- Fixed a native crash (`EXCEPTION_ACCESS_VIOLATION` in `Collection_objects_begin`)
+  when creating a large takeoff grid and then opening the LEDs panel while a light
+  effect is active. The updater no longer caches `Collection.objects` across
+  depsgraph updates on the same frame. Many thanks to [@VGYO](https://github.com/VGYO).
+
 ## [5.0.3] - 2026-08-14
 
 ### Fixed

--- a/src/modules/sbstudio/plugin/operators/create_takeoff_grid.py
+++ b/src/modules/sbstudio/plugin/operators/create_takeoff_grid.py
@@ -326,6 +326,13 @@ class CreateTakeoffGridOperator(Operator):
         return {"FINISHED"}
 
     def _run(self, context):
+        from sbstudio.plugin.tasks.light_effects import suspended_light_effects
+        from sbstudio.plugin.tasks.safety_check import suspended_safety_checks
+
+        with suspended_safety_checks(), suspended_light_effects():
+            self._create_takeoff_grid(context)
+
+    def _create_takeoff_grid(self, context):
         bpy.ops.skybrush.prepare()
 
         points = create_points_of_takeoff_grid(

--- a/src/modules/sbstudio/plugin/tasks/light_effects/session.py
+++ b/src/modules/sbstudio/plugin/tasks/light_effects/session.py
@@ -66,7 +66,12 @@ class LightEffectUpdateSession:
         assert self._frame is not None
 
         if self._context is None:
-            drones, base_colors = self._owner._create_mutable_color_array_for_drones()
+            # Re-fetch Collection.objects for this session. Caching that RNA
+            # wrapper across depsgraph updates (for example after linking many
+            # drones on the same frame) leaves a dangling pointer; len() then
+            # crashes in Collection_objects_begin / RNA_id_pointer_create.
+            drones = self._owner.get_drone_collection(self._scene)
+            base_colors = self._owner._create_mutable_color_array_for_drones(drones)
             self._context = LightEffectEvaluationContext(
                 drones=drones,
                 positions=ObjectPositions(drones),

--- a/src/modules/sbstudio/plugin/tasks/light_effects/updater.py
+++ b/src/modules/sbstudio/plugin/tasks/light_effects/updater.py
@@ -1,5 +1,6 @@
 from typing import Callable
 
+import bpy
 from bpy.types import CollectionObjects, Object, Scene
 from numpy import empty, float32
 from numpy.typing import NDArray
@@ -51,14 +52,13 @@ class LightEffectUpdater:
     `None` if the base colors have not been cached for the current frame yet.
     """
 
-    _last_drone_collection: CollectionObjects | None = None
-    """The collection of drones that were last used to produce a mutable array of colors
-    internally. Used by `get_base_color_of_drone()` to populate the base color cache
-    when it is empty.
-    """
-
     _last_frame: int | None = None
     """Index of the last frame that was evaluated with `update_light_effects()`"""
+
+    _running: bool = False
+    """True while `update()` is on the call stack. Writing colors back to drones
+    tags the depsgraph and would otherwise re-enter this callback.
+    """
 
     _session: LightEffectUpdateSession
     """The light effect update session that allows the user to apply light effects
@@ -81,7 +81,17 @@ class LightEffectUpdater:
             drone_collection_getter or self._get_drone_collection
         )
         self._drone_to_row_index = None
+        self._running = False
         self._session = LightEffectUpdateSession(self)
+
+    def get_drone_collection(self, scene: Scene) -> CollectionObjects:
+        """Returns a fresh RNA wrapper for the current drone collection.
+
+        Do not cache the returned `Collection.objects` across depsgraph updates.
+        Blender may free or rebuild that wrapper, and a later `len()` then
+        crashes in `Collection_objects_begin`.
+        """
+        return self._drone_collection_getter(scene)
 
     def get_base_color_of_drone(self, drone: Object) -> RGBAColor:
         """Returns the (cached) base color of the drone at the current frame
@@ -136,6 +146,16 @@ class LightEffectUpdater:
             the updates to apply to the drones in the scene, or `LightEffectUpdate.NOP`
             if no updates are to be applied
         """
+        if self._running:
+            return LightEffectUpdate.NOP
+
+        self._running = True
+        try:
+            return self._update(scene)
+        finally:
+            self._running = False
+
+    def _update(self, scene: Scene) -> LightEffectUpdate:
         light_effects = scene.skybrush.light_effects
         if not light_effects or not light_effects.enabled:
             self._ensure_session_not_running()
@@ -145,7 +165,6 @@ class LightEffectUpdater:
         frame = scene.frame_current
         if self._last_frame != frame:
             self._last_frame = frame
-            self._last_drone_collection = self._drone_collection_getter(scene)
             self._clear_base_colors()
 
         try:
@@ -167,25 +186,14 @@ class LightEffectUpdater:
 
     def _create_mutable_color_array_for_drones(
         self,
-    ) -> tuple[CollectionObjects, NDArray[float32]]:
-        """Creates a mutable color array from the current collection of drones, set up
-        earlier in `update()`. This color array caan be used during light effect
-        calculations to update the colors.
+        drones: CollectionObjects,
+    ) -> NDArray[float32]:
+        """Creates a mutable color array from the given collection of drones that can
+        be used during light effect calculations to update the colors.
 
         The returned array contains as many rows as the number of drones in the input
         collection. The i-th row stores the color of the i-th drone, in RGBA order.
-
-        Returns:
-            A tuple of the collection of drones and the mutable color array.
         """
-        drones = self._last_drone_collection
-        if drones is None:
-            raise RuntimeError(
-                "Cannot create a mutable color array for drones because the last "
-                "drone collection is not set. This usually means that the update() "
-                "method has not been called yet."
-            )
-
         n = len(drones)
         if not self._drone_to_row_index or n != self._base_colors.shape[0]:
             # Either we have no base colors yet, or the number of drones has changed.
@@ -201,9 +209,9 @@ class LightEffectUpdater:
             # These are shortcomings that we can live with for now as they can easily
             # be fixed by changing to a different frame and then back to the current
             # frame.
-            self._populate_base_color_cache()
+            self._populate_base_color_cache(drones)
 
-        return drones, self._base_colors.copy()
+        return self._base_colors.copy()
 
     def _ensure_session_not_running(self) -> None:
         """Ensures that no session is currently active."""
@@ -216,7 +224,9 @@ class LightEffectUpdater:
         """Returns whether there are already some cached base colors in the cache."""
         return bool(self._drone_to_row_index)
 
-    def _populate_base_color_cache(self) -> None:
+    def _populate_base_color_cache(
+        self, drones: CollectionObjects | None = None
+    ) -> None:
         """Populates the base color cache with the colors of the drones in the current
         frame.
 
@@ -226,18 +236,18 @@ class LightEffectUpdater:
 
         Upon exiting this function, it is guaranteed that self._drone_to_row_index is
         not None and self._base_colors has the same number of rows as the number of
-        drones in self._last_drone_collection.
+        drones in the given collection.
         """
-        if not self._last_drone_collection:
+        if drones is None:
+            scene = getattr(bpy.context, "scene", None)
+            drones = self._drone_collection_getter(scene) if scene else None
+
+        if drones is None:
             self._base_colors = empty((0, 4), dtype=float32)
             self._drone_to_row_index = {}
             return
 
-        n = len(self._last_drone_collection)
+        n = len(drones)
         self._base_colors = empty((n, 4), dtype=float32)
-        get_colors_of_drones_fast(
-            self._last_drone_collection, dest=self._base_colors.ravel()
-        )
-        self._drone_to_row_index = {
-            drone: i for i, drone in enumerate(self._last_drone_collection)
-        }
+        get_colors_of_drones_fast(drones, dest=self._base_colors.ravel())
+        self._drone_to_row_index = {drone: i for i, drone in enumerate(drones)}


### PR DESCRIPTION
## Summary
- Stop caching `Collection.objects` RNA wrappers in `LightEffectUpdater` across depsgraph updates on the same frame.
- Re-fetch the drone collection for each light-effect session instead of reusing `_last_drone_collection`.
- Guard against re-entrant `depsgraph_update_post` while colors are written back to drones.
- Suspend light-effect and safety-check callbacks while creating a takeoff grid so the collection is not evaluated mid-link.

## Bug
On Skybrush Studio 5.0.3 (still present on `main`), Blender can crash with `EXCEPTION_ACCESS_VIOLATION` in `RNA_id_pointer_create` / `Collection_objects_begin` after creating a large takeoff grid and opening the LEDs panel.

Python backtrace from the crash log:

```
File .../light_effects/updater.py, line 151, in _create_mutable_color_array_for_drones
    n = len(drones)
File .../light_effects/session.py, line 66, in _ensure_context
File .../light_effects/session.py, line 58, in apply_effect
File .../light_effects/updater.py, line 128, in update
File .../light_effects/__init__.py, line 43, in update_light_effects
```

Native stack: `pyrna_prop_collection_length` → `RNA_property_collection_length` → `Collection_objects_begin` → `RNA_id_pointer_create`.

**Cause:** `_last_drone_collection` stores `Collection.objects` and only refreshes it when the frame index changes. `create_takeoff_grid` links hundreds or thousands of drones on the **same frame**, so the cached RNA pointer becomes stale. `len()` on that wrapper then crashes in Blender's C code.

## How to reproduce
1. Install Skybrush Studio 5.0.3 (or current `main`) in Blender 4.4+ / 5.2.
2. Start a new file and enable the add-on.
3. Add a light effect that is **enabled on the current frame** (Skybrush tab → Light effects → Add). Leave the playhead on that frame.
4. Run **Create Takeoff Grid** with a large swarm, for example 28 rows × 50 columns (1400 drones). Confirm the operator. **Do not change the frame.**
5. In the 3D Viewport, open the N-panel and switch the category to **LEDs**.
6. Blender crashes. The crash log shows `EXCEPTION_ACCESS_VIOLATION` in `Collection_objects_begin`, with the Python backtrace above.

Notes:
- The crash requires at least one **active** light effect on the current frame (`apply_effect` is on the stack).
- A workaround without this patch is to step the playhead by one frame after creating the grid, which forces the cached collection to be refreshed.

## Test plan
- [ ] Follow the reproduction steps above with this build — Blender stays up and the LEDs panel opens
- [ ] A smaller grid (for example 4×4) still creates drones, and light effects still update when scrubbing the timeline
- [ ] Disable all light effects, create a large grid, open LEDs — no crash
- [ ] After creating a grid, change the current frame — drone colors still update

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed a native crash that could occur when creating a large takeoff grid and opening the LEDs panel while a light effect was active.
  - Improved stability when light effects update during scene changes, preventing stale collection data and re-entrant updates.
  - Light effects are now temporarily suspended while creating a takeoff grid to ensure reliable operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->